### PR TITLE
buffer sizes can now be specified and will be set on the udp socket

### DIFF
--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -84,7 +84,18 @@ public:
     void nameserver(const Ip &ip)
     {
         // add to the member in the base class
-        _nameservers.emplace_back(_loop, ip);
+        _nameservers.emplace_back(static_cast<Core*>(this), ip);
+    }
+
+    /**
+     *  The send and receive buffer size 
+     *  @param  size      the requested buffer size in bytes, or default with 0. 
+     *                    only gets applied to new sockets.
+     */
+    void buffersize(int32_t size) 
+    {
+        // store the property
+        _buffersize = size;
     }
     
     /**

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -58,6 +58,13 @@ protected:
     Hosts _hosts;
     
     /**
+     *  Size of the send and receive buffer. If set to zero, default
+     *  will be kept. This is limited by the system maximum (wmem_max and rmem_max)
+     *  @var size_t
+     */
+    int32_t _buffersize = 0;
+
+    /**
      *  Max time that a request may last in seconds
      *  @var double
      */
@@ -104,7 +111,7 @@ protected:
         for (size_t i = 0; i < settings.nameservers(); ++i)
         {
             // construct a nameserver
-            _nameservers.emplace_back(_loop, settings.nameserver(i));
+            _nameservers.emplace_back(this, settings.nameserver(i));
         }
     }
     
@@ -125,6 +132,12 @@ public:
      *  @return Loop
      */
     Loop *loop() { return _loop; }
+
+    /**
+     *  The send and receive buffer size 
+     *  @return int32_t
+     */
+    int32_t buffersize() const { return _buffersize; }
     
     /**
      *  The period between sending a new datagram to the same nameserver in seconds

--- a/include/dnscpp/nameserver.h
+++ b/include/dnscpp/nameserver.h
@@ -32,6 +32,11 @@
 namespace DNS {
 
 /**
+ *  Forward declaration
+ */
+class Core;
+
+/**
  *  Class definition
  */
 class Nameserver : private Udp::Handler
@@ -132,11 +137,11 @@ private:
 public:
     /**
      *  Constructor
-     *  @param  loop    event loop
+     *  @param  core    the core object with the settings and event loop
      *  @param  ip      nameserver IP
      *  @throws std::runtime_error
      */
-    Nameserver(Loop *loop, const Ip &ip) : _ip(ip), _udp(loop, this) {}
+    Nameserver(Core *core, const Ip &ip) : _ip(ip), _udp(core, this) {}
     
     /**
      *  No copying

--- a/include/dnscpp/udp.h
+++ b/include/dnscpp/udp.h
@@ -31,6 +31,7 @@ namespace DNS {
 /**
  *  Forward declarations
  */
+class Core;
 class Query;
 class Loop;
 class Ip;
@@ -56,13 +57,20 @@ public:
          */
         virtual void onReceived(const Ip &ip, const unsigned char *response, size_t size) = 0;
     };
+
+    /**
+     *  Helper method to set an integer socket option
+     *  @param  optname
+     *  @param  optval
+     */
+    int setintopt(int optname, int32_t optval);
     
 private:
     /**
-     *  The event loop in user space
-     *  @var Loop
+     *  The core object
+     *  @var Core
      */
-    Loop *_loop;
+    Core *_core;
     
     /**
      *  The filedescriptor of the socket
@@ -107,11 +115,11 @@ private:
 public:
     /**
      *  Constructor
-     *  @param  loop        event loop in user space
+     *  @param  core        the core object
      *  @param  handler     object that will receive all incoming responses
      *  @throws std::runtime_error
      */
-    Udp(Loop *loop, Handler *handler);
+    Udp(Core *core, Handler *handler);
     
     /**
      *  No copying

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -32,7 +32,7 @@ Core::Core(Loop *loop, bool defaults) : _loop(loop)
     ResolvConf settings;
     
     // copy the nameservers
-    for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(loop, settings.nameserver(i));
+    for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(this, settings.nameserver(i));
     
     // we also have to load /etc/hosts
     if (!_hosts.load()) throw std::runtime_error("failed to load /etc/hosts");


### PR DESCRIPTION
This prevents UDP packets from being dropped because the receive buffer is full too early.