### PR TITLE
read out the buffer and later, during idle, relay messages back.

### DIFF
--- a/include/dnscpp/idle.h
+++ b/include/dnscpp/idle.h
@@ -1,0 +1,49 @@
+/**
+ *  Idle.h
+ *
+ *  When the DNS library wants the event loop to set a idle watcher, it passes 
+ *  a idle object to user space (see the Loop class). It is up to the 
+ *  user space code to call the idle() method when the idle watcher is activated.
+ *
+ *  @author Michael van der Werve <michael.vanderwerve@mailerq.com>
+ *  @copyright 2020 Copernica BV
+ */
+
+/**
+ *  Include guard
+ */
+#pragma once
+
+/**
+ *  Begin of namespace
+ */
+namespace DNS {
+ 
+/**
+ *  Class definition
+ */
+class Idle
+{
+protected:
+    /**
+     *  User space should not construct or destruct idle objects,
+     *  hence the constructor and destructor are protected
+     */
+    Idle() = default;
+    
+    /**
+     *  Destructor is protected too
+     */
+    virtual ~Idle() = default;
+
+public:
+    /**
+     *  Notify the idle that we're idle
+     */
+    virtual void idle() = 0;
+};
+    
+/**
+ *  End of namespace
+ */
+}

--- a/include/dnscpp/libev.h
+++ b/include/dnscpp/libev.h
@@ -71,6 +71,21 @@ private:
         timer->expire();
     }
 
+    /**
+     *  Callback method that is called when the event loop is idle
+     *  @param  loop        The loop in which the event was triggered
+     *  @param  w           Internal watcher object
+     *  @param  revents     Events triggered
+     */
+    static void idle(struct ev_loop *loop, ev_idle *watcher, int revents)
+    {
+        // retrieve the timer
+        Idle *idle = (Idle *)watcher->data;
+
+        // notify the timer
+        idle->idle();
+    }
+
 public:
     /**
      *  Constructor
@@ -211,6 +226,53 @@ public:
         
         // remove the watcher from the event loop
         ev_timer_stop(_loop, watcher);
+        
+        // we no longer need the watcher
+        free(watcher);
+    }
+
+    /**
+     *  Set an idle watcher
+     *  @param  handler  the object that should be notified when there is time
+     *  @return void*   identifier for the timer
+     */
+    virtual void *idle(Idle *handler) override
+    {
+        // construct the watcher object
+        ev_idle *watcher = (ev_idle*)malloc(sizeof(ev_idle));
+        
+        // associate the timer with the watcher
+        watcher->data = handler;
+        
+        // initialize the watcher
+        ev_idle_init(watcher, idle);
+        
+        // start monitoring for activity
+        ev_idle_start(_loop, watcher);
+
+        // dont affect refcount
+        if (!_persist) ev_unref(_loop);
+        
+        // expose the watcher as identifier
+        return watcher;
+    }
+
+    /**
+     *  Method that is called when a idle watcher is cancelled. This is called when
+     *  the DNS library no longer needs to be notified of the application being idle.
+     * 
+     *  @param  void*   identifier of the watcher
+     */
+    virtual void cancel(void *identifier, Idle *idle) override
+    {
+        // restore refcount
+        if (!_persist) ev_ref(_loop);
+
+        // the identifier is a watcher
+        ev_idle *watcher = (ev_idle *)identifier;
+        
+        // remove the watcher from the event loop
+        ev_idle_stop(_loop, watcher);
         
         // we no longer need the watcher
         free(watcher);

--- a/include/dnscpp/loop.h
+++ b/include/dnscpp/loop.h
@@ -27,6 +27,7 @@ namespace DNS {
  */
 class Monitor;
 class Timer;
+class Idle;
 
 /**
  *  Class definition
@@ -100,6 +101,21 @@ public:
      *  @param  void*   identifier of the timer (returned by the timer() method)
      */
     virtual void cancel(void *identifier, Timer *timer) = 0;
+
+    /**
+     *  Set an idle watcher
+     *  @param  Idle the object that should be notified when there is time
+     *  @return void*   identifier for the timer
+     */
+    virtual void *idle(Idle *idle) = 0;
+
+    /**
+     *  Method that is called when a idle watcher is cancelled. This is called when
+     *  the DNS library no longer needs to be notified of the application being idle.
+     * 
+     *  @param  void*   identifier of the watcher
+     */
+    virtual void cancel(void *identifier, Idle *idle) = 0;
 };
     
 /**

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -44,6 +44,9 @@ Udp::~Udp()
 {
     // close the socket
     close();
+
+    // stop monitoring the idle state
+    stop();
 }
 
 /**
@@ -90,6 +93,21 @@ bool Udp::open(int version)
 }
 
 /**
+ *  Helper method to stop monitoring the idle state
+ */
+void Udp::stop()
+{
+    // nothing to do if not checking for idle
+    if (_idle == nullptr) return;
+
+    // cancel the idle watcher
+    _core->loop()->cancel(_idle, this);
+
+    // forget the ptr
+    _idle = nullptr;
+}
+
+/**
  *  Close the socket
  *  @return bool
  */
@@ -117,31 +135,52 @@ bool Udp::close()
  */
 void Udp::notify()
 {
+    // do nothing if there is no socket (how is that possible!?)
+    if (_fd < 0) return;
+    
+    // the buffer to receive the response in
+    // @todo use a macro
+    char buffer[65536];
+
+    // structure will hold the source address (we use an ipv6 struct because that is also big enough for ipv4)
+    struct sockaddr_in6 from; socklen_t fromlen = sizeof(from);
+    
+    // reveive the message
+    auto bytes = recvfrom(_fd, buffer, sizeof(buffer), 0, (struct sockaddr *)&from, &fromlen);
+    
+    // add to the responses
+    _responses.emplace_back(Ip((struct sockaddr *)&from), std::string(buffer, bytes));
+
+    // if we're already processing, we don't need to install idle watcher
+    if (_idle) return;
+
+    // create a new idle watcher now
+    _idle = _core->loop()->idle(this);
+}
+
+/**
+ *  Method that is called from user-space when the timer expires.
+ */
+void Udp::idle()
+{
+    // if there is nothing to do, we can stop the watcher (no more responses to feed back)
+    if (_responses.empty()) return stop();
+
     // prevent exceptions (parsing the ip could fail)
     try
     {
-        // do nothing if there is no socket (how is that possible!?)
-        if (_fd < 0) return;
-        
-        // the buffer to receive the response in
-        // @todo use a macro
-        unsigned char buffer[65536];
+        // get the first element
+        auto front = _responses.front();
 
-        // structure will hold the source address (we use an ipv6 struct because that is also big enough for ipv4)
-        struct sockaddr_in6 from; socklen_t fromlen = sizeof(from);
-        
-        // reveive the message
-        auto bytes = recvfrom(_fd, buffer, sizeof(buffer), 0, (struct sockaddr *)&from, &fromlen);
-        
-        // find the ip address from which the message was received
-        Ip ip((struct sockaddr *)&from);
-        
-        // notify the handler
-        _handler->onReceived(ip, buffer, bytes);
+        // get the first element
+        _handler->onReceived(front.first, (unsigned char*)front.second.c_str(), front.second.size());
+
+        // pop the front
+        _responses.pop_front();
     }
     catch (const std::runtime_error &error)
     {
-        // report the error
+        // @todo report the error
     }
 }
 


### PR DESCRIPTION
This improves the performance and lowers the dropped packets a fair bit, but we're still dropping too many packets which is suboptimal.