### PR TITLE
Two extra options from resolv.conf

### DIFF
--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -176,6 +176,15 @@ public:
      */
     Operation *query(const DNS::Ip &ip, const SuccessCallback &success, const FailureCallback &failure);
     
+    /**
+     *  Expose some getters from core
+     */
+    using Core::buffersize;
+    using Core::dnssec;
+    using Core::rotate;
+    using Core::spread;
+    using Core::expire;
+    using Core::interval;
 };
     
 /**

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -120,6 +120,12 @@ protected:
             _nameservers.emplace_back(this, settings.nameserver(i));
         }
 
+        // the timeout value is the time before moving on to the next server
+        _spread = settings.timeout();
+
+        // the attempts divided by the expire time will be the interval
+        _interval = _expire / settings.attempts();
+
         // set the rotate setting
         _rotate = settings.rotate();
     }

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -89,6 +89,12 @@ protected:
      */
     bool _dnssec = false;
 
+    /**
+     *  Should all nameservers be rotated? otherwise they will be tried in-order
+     *  @var bool
+     */
+    bool _rotate = false;
+
 protected:
     /**
      *  Protected constructor, only the derived class may construct it
@@ -113,6 +119,9 @@ protected:
             // construct a nameserver
             _nameservers.emplace_back(this, settings.nameserver(i));
         }
+
+        // set the rotate setting
+        _rotate = settings.rotate();
     }
     
     /**
@@ -162,6 +171,12 @@ public:
      *  @return bool
      */
     bool dnssec() const { return _dnssec; }
+
+    /**
+     *  Should all nameservers be rotated? otherwise they will be tried in-order
+     *  @var bool
+     */
+    bool rotate() const { return _rotate; }
     
     /**
      *  Does a certain hostname exists in /etc/hosts? In that case a NXDOMAIN error should not be given

--- a/include/dnscpp/resolvconf.h
+++ b/include/dnscpp/resolvconf.h
@@ -17,6 +17,7 @@
  *  Dependencies
  */
 #include <vector>
+#include <resolv.h>
 
 /**
  *  Begin of namespace
@@ -34,6 +35,18 @@ private:
      *  @var std::vector<Ip>
      */
     std::vector<Ip> _nameservers;
+
+    /**
+     *  Timeout as specified in the conf.
+     *  @var size_t
+     */
+    size_t _timeout = RES_TIMEOUT;
+
+    /**
+     *  How many attempts to make 
+     *  @var size_t
+     */
+    size_t _attempts = RES_DFLRETRY;
 
     /**
      *  Rotate, see man resolvconf. This indicates if the nameservers should be tried in-order
@@ -121,6 +134,18 @@ public:
      *  @return bool
      */
     bool rotate() const { return _rotate; }
+
+    /**
+     *  Timeout to use before going to a different nameserver.
+     *  @return size_t
+     */
+    size_t timeout() const { return _timeout; }
+
+    /**
+     *  Number of attempts to make before giving up.
+     *  @return size_t
+     */
+    size_t attempts() const { return _attempts; }
 };
     
 /**

--- a/include/dnscpp/resolvconf.h
+++ b/include/dnscpp/resolvconf.h
@@ -36,6 +36,13 @@ private:
     std::vector<Ip> _nameservers;
 
     /**
+     *  Rotate, see man resolvconf. This indicates if the nameservers should be tried in-order
+     *  or if the load can be distributed among them.
+     *  @var bool
+     */
+    bool _rotate = false;
+
+    /**
      *  Helper method to parse lines
      *  @param  line        the line to parse (must already be trimmed)
      *  @param  size        size of the line
@@ -68,12 +75,19 @@ private:
     void search(const char *line, size_t size);
 
     /**
-     *  Add an option
+     *  Add an options line
      *  @param  line        the value to parse
      *  @param  size        size of the line
      *  @throws std::runtime_error
      */
     void options(const char *line, size_t size);
+
+    /**
+     *  Add an option
+     *  @param  option  
+     *  @param  size
+     */
+    void option(const char *option, size_t size);
 
 public:
     /**
@@ -101,6 +115,12 @@ public:
      *  @return Ip
      */
     const Ip &nameserver(size_t index) const { return _nameservers[index]; }
+
+    /**
+     *  Whether or not the 'rotate' option is set in the resolve conf
+     *  @return bool
+     */
+    bool rotate() const { return _rotate; }
 };
     
 /**

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -34,6 +34,15 @@ Core::Core(Loop *loop, bool defaults) : _loop(loop)
     // copy the nameservers
     for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(this, settings.nameserver(i));
     
+    // the timeout value is the time before moving on to the next server
+    _spread = settings.timeout();
+
+    // the attempts divided by the expire time will be the interval
+    _interval = _expire / settings.attempts();
+
+    // set the rotate setting
+    _rotate = settings.rotate();
+
     // we also have to load /etc/hosts
     if (!_hosts.load()) throw std::runtime_error("failed to load /etc/hosts");
 }

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -139,9 +139,10 @@ void RemoteLookup::timeout()
  */
 void RemoteLookup::retry(double now)
 {
-    // we need some "random" identity because we do not want all jobs to start with 
-    // nameserver[0] -- for this we use the starttime as it is random-enough to distribute requests
-    size_t id = _started * 100000;
+    // we need some "random" identity if the rotate option is set because we do not want all jobs to start with 
+    // nameserver[0] -- for this we use the starttime as it is random-enough to distribute requests. otherwise 
+    // we will always start at nameserver 0
+    size_t id = _core->rotate() ? _started * 100000 : 0;
     
     // access to the nameservers + the number we have
     auto &nameservers = _core->nameservers();

--- a/src/resolvconf.cpp
+++ b/src/resolvconf.cpp
@@ -175,8 +175,37 @@ void ResolvConf::search(const char *line, size_t size)
  */
 void ResolvConf::options(const char *line, size_t size)
 {
-    // report error
-    throw std::runtime_error(std::string("not implemented: options ") + line);
+    // define the start and the line
+    const char *start = line;
+    const char *space = strchr(start, ' ');
+
+    // iterate over the options, separate by spaces
+    while (start)
+    {
+        // process the option
+        option(start, space ? space - start : size - (start - line));
+
+        // if there was no space, we're reached the end of the line, and we're done
+        if (!space) return;
+
+        // find the next space
+        start = space + 1;
+        space = strchr(start, ' ');
+    }
+}
+
+/**
+ *  Add an option
+ *  @param  option  
+ *  @param  size
+ */
+void ResolvConf::option(const char *option, size_t size)
+{
+    // if the option is empty, there is nothing to check
+    if (size == 0) return;
+
+    // check if this is the rotate option
+    if (strcmp(option, "rotate")) _rotate = true;
 }
   
 /**

--- a/src/resolvconf.cpp
+++ b/src/resolvconf.cpp
@@ -14,6 +14,7 @@
 #include "../include/dnscpp/resolvconf.h"
 #include <ctype.h>
 #include <fstream>
+#include <iostream>
 
 /**
  *  Begin of namespace
@@ -205,7 +206,15 @@ void ResolvConf::option(const char *option, size_t size)
     if (size == 0) return;
 
     // check if this is the rotate option
-    if (strcmp(option, "rotate")) _rotate = true;
+    if (strcmp(option, "rotate") == 0) _rotate = true;
+    
+    // maybe this is the timeout option, needs to be capped to 30 (per the conf)
+    else if (strncmp(option, "timeout:", 8) == 0) _timeout = std::min(30, atoi(option + 8));
+
+    // maybe this is the attempts option? parse it and cap it to 5.
+    else if (strncmp(option, "attempts:", 9) == 0) _attempts = std::min(5, atoi(option + 9));
+
+    // unknown option...
 }
   
 /**


### PR DESCRIPTION
```
              timeout:n
                     Sets the amount of time the resolver will wait for a
                     response from a remote name server before retrying the
                     query via a different name server.  This may not be the
                     total time taken by any resolver API call and there is
                     no guarantee that a single resolver API call maps to a
                     single timeout.  Measured in seconds, the default is
                     RES_TIMEOUT (currently 5, see <resolv.h>).  The value
                     for this option is silently capped to 30.

              attempts:n
                     Sets the number of times the resolver will send a query
                     to its name servers before giving up and returning an
                     error to the calling application.  The default is
                     RES_DFLRETRY (currently 2, see <resolv.h>).  The value
                     for this option is silently capped to 5.
```