### PR TITLE
Add setter for Rotate to Context

### DIFF
--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -159,6 +159,12 @@ public:
      *  @param  value
      */
     void bits(const Bits &bits) { _bits = bits; }
+
+    /**
+     *  Set the rotate setting: If true, nameservers will be rotated, if false, nameservers are tried in-order
+     *  @param rotate   the new setting
+     */
+    void rotate(bool rotate) { _rotate = rotate; }
     
     /**
      *  Do a dns lookup and pass the result to a user-space handler object


### PR DESCRIPTION
A way to set Rotate in Core/Context is missing, this PR adds the missing getter