### PR TITLE
Prevent one buffer copy 

### DIFF
--- a/include/dnscpp/message.h
+++ b/include/dnscpp/message.h
@@ -168,7 +168,7 @@ public:
      *  Is the message truncated? In that case it is better to use tcp
      *  @return bool
      */
-    bool truncated() const { return flag(ns_f_tc); }
+    bool truncated() const { if (rand() % 2 == 0) return true; else return flag(ns_f_tc); }
     
     /**
      *  Is recursion desired (false for responses)

--- a/include/dnscpp/message.h
+++ b/include/dnscpp/message.h
@@ -168,7 +168,7 @@ public:
      *  Is the message truncated? In that case it is better to use tcp
      *  @return bool
      */
-    bool truncated() const { if (rand() % 2 == 0) return true; else return flag(ns_f_tc); }
+    bool truncated() const { /*if (rand() % 2 == 0) return true; else*/ return flag(ns_f_tc); }
     
     /**
      *  Is recursion desired (false for responses)

--- a/include/dnscpp/query.h
+++ b/include/dnscpp/query.h
@@ -24,6 +24,12 @@
  */
 namespace DNS {
 
+// we advertise that we support 1200 bytes for our response buffer size,
+// this is the same buffer size as libresolv seems to use. Their ratio
+// is that this limits the risk that dgram message get fragmented,
+// which makes the system vulnerable for injection
+constexpr size_t EDNSPacketSize = 1200;
+
 /**
  *  Forward declarations
  */

--- a/include/dnscpp/socket.h
+++ b/include/dnscpp/socket.h
@@ -56,7 +56,7 @@ private:
      *  All the buffered responses that came in
      *  @var std::list
      */
-    std::list<std::pair<Ip,std::basic_string<unsigned char>>> _responses;
+    std::list<std::pair<Ip,std::vector<unsigned char>>> _responses;
 
 protected:
     /**
@@ -74,10 +74,9 @@ protected:
      *  Add a message for delayed processing
      *  @param  addr    the address from which the message was received
      *  @param  buffer  the response buffer
-     *  @param  size    size of the buffer
      */
-    void add(const sockaddr *addr, const unsigned char *buffer, size_t size);
-    void add(const Ip &addr, const unsigned char *buffer, size_t size);
+    void add(const sockaddr *addr, std::vector<unsigned char> &&buffer);
+    void add(const Ip &addr, std::vector<unsigned char> &&buffer);
 
 public:
     /**

--- a/include/dnscpp/tcp.h
+++ b/include/dnscpp/tcp.h
@@ -71,19 +71,25 @@ private:
      *  @var int
      */
     int _fd;
-    
+
     /**
-     *  The buffer that is being filled right now (first two bytes contain the size)
-     *  @var unsigned char *
+     *  Size of the buffer to fill
+     *  @var uint16_t
+     */
+    uint16_t _size;
+
+    /**
+     *  The response that is being filled right now
+     *  @var vector
      */
     std::vector<unsigned char> _buffer;
     
     /**
-     *  How far is the _buffer now filled?
+     *  How many bytes of the frame were transferred?
      *  @var size_t
      */
-    size_t _filled = 0;
-    
+    size_t _transferred = 0;
+
     /**
      *  Identifier user for monitoring the filedescriptor in the event loop
      *  @var void *
@@ -140,18 +146,6 @@ private:
      */
     virtual void notify() override;
 
-    /**
-     *  Reallocate the buffer if it turns out that our buffer is too small for the expected response
-     *  @return bool
-     */
-    bool reallocate();
-
-    /**
-     *  Size of the response -- this method only works if we have already received the frist two bytes
-     *  @return uint16_t
-     */
-    uint16_t responsesize() const;
-    
     /**
      *  Number of bytes that we expect in the next read operation
      *  @return size_t

--- a/include/dnscpp/tcp.h
+++ b/include/dnscpp/tcp.h
@@ -151,6 +151,13 @@ private:
      *  @return size_t
      */
     size_t expected() const;
+
+    /**
+     *  Check return value of a recv syscall
+     *  @param  bytes  The bytes transferred
+     *  @return true if we should leap out (an error occurred or we'd block), false if not
+     */
+    bool updatetransferred(ssize_t bytes);
     
     /**
      *  Method that is called when there are no more subscribers, and that 

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -194,12 +194,9 @@ bool Query::edns(bool dnssec)
     
     // the type of the pseudo-record is "opt"
     put16(TYPE_OPT);
-    
-    // we advertise that we support 1200 bytes for our response buffer size, 
-    // this is the same buffer size as libresolv seems to use. Their ratio
-    // is that this limits the risk that dgram message get fragmented,
-    // which makes the system vulnerable for injection
-    put16(1200);
+
+    // tell the server that we support larger UDP packets
+    put16(EDNSPacketSize);
     
     // extended rcode (0 because the normal rcode is good enough) and the 
     // edns version (also 0 because that is the mose up-to-date version)

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -24,9 +24,8 @@ namespace DNS {
  *  Add a message for delayed processing
  *  @param  addr    the address from which the message was received
  *  @param  buffer  the response buffer
- *  @param  size    size of the buffer
  */
-void Socket::add(const sockaddr *addr, const unsigned char *buffer, size_t size)
+void Socket::add(const sockaddr *addr, std::vector<unsigned char> &&buffer)
 {
     // avoid exceptions (in case the ip cannot be parsed)
     try
@@ -34,8 +33,7 @@ void Socket::add(const sockaddr *addr, const unsigned char *buffer, size_t size)
         // @todo inbound messages that do not come from port 53 can be ignored
 
         // remember the response for now
-        // @todo make this more efficient (without all the string-copying)
-        _responses.emplace_back(addr, std::basic_string<unsigned char>(buffer, size));
+        _responses.emplace_back(addr, move(buffer));
     }
     catch (...)
     {
@@ -50,12 +48,11 @@ void Socket::add(const sockaddr *addr, const unsigned char *buffer, size_t size)
  *  Add a message for delayed processing
  *  @param  addr    the address from which the message was received
  *  @param  buffer  the response buffer
- *  @param  size    size of the buffer
  */
-void Socket::add(const Ip &addr, const unsigned char *buffer, size_t size)
+void Socket::add(const Ip &addr, std::vector<unsigned char> &&buffer)
 {
     // add to the list
-    _responses.emplace_back(addr, std::basic_string<unsigned char>(buffer, size));
+    _responses.emplace_back(addr, move(buffer));
 
     // reschedule the processing of messages
     _handler->onBuffered(this);

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -184,7 +184,7 @@ size_t Tcp::expected() const
     switch (_transferred) {
     case 0:     return sizeof(uint16_t);
     case 1:     return sizeof(uint16_t) - 1;
-    default:    return _size - _transferred - sizeof(uint16_t);
+    default:    return _size - (_transferred - sizeof(uint16_t));
     }
 }
 

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -287,10 +287,13 @@ void Tcp::notify()
         _buffer.resize(_size);
     }
 
+    // calculate offset into the buffer
+    size_t offset = _transferred - sizeof(uint16_t);
+
     // This is the second state of the Tcp state machine. At this point we know we have
     // received at least two bytes of the frame, and so we know we have resized the
     // buffer accordingly. All that's left to do is to await the full response content
-    if (updatetransferred(::recv(_fd, _buffer.data() + _transferred - sizeof(uint16_t), _buffer.size() - _transferred + sizeof(uint16_t), MSG_DONTWAIT))) return;
+    if (updatetransferred(::recv(_fd, _buffer.data() + offset, _buffer.size() - offset, MSG_DONTWAIT))) return;
 
     // continue waiting if we have not yet received everything there is
     if (expected() > 0) return;

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -281,7 +281,7 @@ void Tcp::notify()
 
         // OK: the size of the rest of the frame was received, we know how much to allocate
         // update the size
-        _size = htons(_size);
+        _size = ntohs(_size);
 
         // size the buffer accordingly
         _buffer.resize(_size);

--- a/test/stress.cpp
+++ b/test/stress.cpp
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
     context.buffersize(1024 * 1024); // size of the input buffer (high lowers risk of package loss)
     context.interval(3.0);           // number of seconds until the datagram is retried (possibly to next server) (this does not cancel previous requests)
     context.attempts(10);            // number of attempts until failure / number of datagrams to send at most
-    context.capacity(1024);          // max number of simultaneous lookups per dns-context (high increases speed but also risk of package-loss)
+    context.capacity(128);           // max number of simultaneous lookups per dns-context (high increases speed but also risk of package-loss)
     context.timeout(3.0);            // time to wait for a response after the _last_ attempt
     context.sockets(4);              // number of sockets
 


### PR DESCRIPTION
I'm fairly certain we cannot do better than this.

Receiving the TCP response is now split into two variables, one uint16_t that will contain the size in network-order which we'll swap to host-order once the 2 bytes are received, and the old _buffer member variable that will now contain just the response and not the response size. This makes it possible to move it into the deferred received list.

Moreover, the packetsize for UDP receive buffer is now sized more conservatively (exactly the EDNS packet size we hint to the server).