### PR TITLE
Handle cancellations properly

### DIFF
--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -162,8 +162,9 @@ public:
     /**
      *  Set the max number of calls that are made to userspace in one iteration
      *  @param  value       the new value
+     *  @deprecated has no effect
      */
-    void maxcalls(size_t value) { _maxcalls = value; }
+    void maxcalls(size_t value) {}
     
     /**
      *  Do a dns lookup and pass the result to a user-space handler object

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -91,13 +91,6 @@ protected:
      *  @var std::deque<std::shared_ptr<Lookup>>
      */
     IntrusiveQueue<Lookup> _lookups;
-
-    /**
-     *  Lookups for which the max number of attempts have been reached (no further
-     *  messages will be sent) and that are waiting for response or expiration
-     *  @var std::deque<std::shared_ptr<Lookup>>
-     */
-    std::deque<std::shared_ptr<Lookup>> _ready;
     
     /**
      *  The next timer to run

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -139,12 +139,6 @@ protected:
     size_t _capacity = 1024;
 
     /**
-     *  The max number of calls to be made to userspace in one iteration
-     *  @var size_t
-     */
-    size_t _maxcalls = 64;
-
-    /**
      *  Calculate the delay until the next job
      *  @return double      the delay in seconds (or < 0 if there is no need to run a timer)
      */

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -76,13 +76,11 @@ protected:
     Hosts _hosts;
 
     /**
-     *  All operations that are in progress and that are waiting for the next 
-     *  (possibly first) attempt. Note that we use multiple queues so that we do
-     *  not have to use a slow (priority) queue.
-     *  @var std::deque<std::shared_ptr<Lookup>>
+     *  All operations that are in progress.
+     *  @var IntrusiveQueue<Lookup>
      */
-    std::deque<std::shared_ptr<Lookup>> _scheduled;
-    
+    IntrusiveQueue<Lookup> _lookups;
+
     /**
      *  To avoid that external DNS servers, or our own response-buffer, is flooded
      *  with data, there is a limit on the number of operations that can run. If
@@ -90,7 +88,7 @@ protected:
      *  overflow (is not supposed to happen often!)
      *  @var std::deque<std::shared_ptr<Lookup>>
      */
-    IntrusiveQueue<Lookup> _lookups;
+    std::deque<std::shared_ptr<Lookup>> _scheduled;
     
     /**
      *  The next timer to run

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -161,19 +161,9 @@ protected:
 
     /**
      *  Proceed with more operations
-     *  @param  watcher
      *  @param  now
      */
-    void proceed(const Watcher &watcher, double now);
-    
-    /**
-     *  Process a lookup
-     *  @param  watcher     object to monitor if `this` was destructed
-     *  @param  lookup      the lookup to process
-     *  @param  now         current time
-     *  @return bool        was this lookup indeed processable (false if processed too early)
-     */
-    bool process(const Watcher &watcher, const std::shared_ptr<Lookup> &lookup, double now);
+    void proceed(double now);
 
     /**
      *  Notify the timer that it expired

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -275,7 +275,7 @@ public:
      *  @param  connector   the object interested in the connection
      *  @return bool
      */
-    bool connect(const Ip &ip, Connector *connector);
+    bool connect(const Ip &ip, std::shared_ptr<Connector> connector);
 
     /**
      *  An inflight lookup is done

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -166,6 +166,14 @@ protected:
     void proceed(double now);
 
     /**
+     *  Invoke callback handlers of a lookup that's done.
+     *  @param  watcher  The watcher to check if we're still valid
+     *  @param  lookup   The lookup
+     *  @return true if we should bail out immediately
+     */
+    bool finalize(const Watcher &watcher, std::shared_ptr<Lookup> &&lookup) const noexcept;
+
+    /**
      *  Notify the timer that it expired
      */
     virtual void expire() override;

--- a/include/dnscpp/intrusivequeue.h
+++ b/include/dnscpp/intrusivequeue.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "intrusivequeueitem.h"
+#include <type_traits>
+
+namespace DNS {
+
+template <class T> class IntrusiveQueue final
+{
+public:
+    static_assert(std::is_base_of<IntrusiveQueueItem<T>, T>::value, "must derive from IntrusiveQueueItem");
+
+    /**
+     *  Push a new item onto the back of the queue.
+     *  @param  item Item to be inserted. The position of the item is remembered inside of the item itself.
+     */
+    void push(const std::shared_ptr<T> &item)
+    {
+        _q.push_back(item);
+        item->position(std::prev(_q.end()));
+    }
+
+    /**
+     *  Pop an item from the front of the queue.
+     *  @return the popped item.
+     */
+    std::shared_ptr<T> pop()
+    {
+        auto result = _q.front();
+        result->clearposition();
+        _q.pop_front();
+        return result;
+    }
+
+    /**
+     *  Pop an item somewhere in the middle of the queue.
+     *  @param    item the item
+     *  @return   true if the item was at the front of the queue, false otherwise
+     */
+    bool pop(IntrusiveQueueItem<T> &item)
+    {
+        if (!item.hasposition()) return false;
+        const auto pos = item.position();
+        const bool atfront = pos == _q.begin();
+        _q.erase(pos);
+        item.clearposition();
+        return atfront;
+    }
+
+    typename std::list<std::shared_ptr<T>>::const_reference front() const noexcept { return _q.front(); }
+
+    /**
+     *  Size of the queue.
+     *  @return size_t
+     */
+    size_t size() const noexcept { return _q.size(); }
+
+    /**
+     *  Is the queue empty?
+     *  @return bool
+     */
+    bool empty() const noexcept { return _q.empty(); }
+
+private:
+    std::list<std::shared_ptr<T>> _q;
+};
+
+} // namespace DNS

--- a/include/dnscpp/intrusivequeue.h
+++ b/include/dnscpp/intrusivequeue.h
@@ -1,10 +1,33 @@
+/**
+ *  intrusivequeue.h
+ *
+ *  Queue datastructure which also allows O(1)
+ *  removal from an item in the middle of the queue.
+ *
+ *  @author Raoul Wols <raoul.wols@copernica.com>
+ *  @copyright 2021 Copernica BV
+ */
+
+/**
+ *  Include guard
+ */
 #pragma once
 
+/**
+ *  Dependencies
+ */
 #include "intrusivequeueitem.h"
 #include <type_traits>
 
+/**
+ *  Begin namespace
+ */
 namespace DNS {
 
+/**
+ *  Class declaration
+ *  @tparam  T  The type of the items. The actual item type will be shared_ptr<T>.
+ */
 template <class T> class IntrusiveQueue final
 {
 public:
@@ -16,7 +39,10 @@ public:
      */
     void push(const std::shared_ptr<T> &item)
     {
+        // insert it at the back
         _q.push_back(item);
+
+        // update position
         item->position(std::prev(_q.end()));
     }
 
@@ -26,9 +52,16 @@ public:
      */
     std::shared_ptr<T> pop()
     {
-        auto result = _q.front();
+        // move it out from the front
+        auto result = move(_q.front());
+
+        // forget the position
         result->clearposition();
+
+        // pop front item
         _q.pop_front();
+
+        // done
         return result;
     }
 
@@ -39,14 +72,29 @@ public:
      */
     bool pop(IntrusiveQueueItem<T> &item)
     {
+        // if it doesn't have a position then we can't remove it
         if (!item.hasposition()) return false;
+
+        // get the remembered position from the item
         const auto pos = item.position();
+
+        // check if we're removing an item at the front of the queue
         const bool atfront = pos == _q.begin();
+
+        // remove it from the queue
         _q.erase(pos);
+
+        // forget the position
         item.clearposition();
+
+        // done
         return atfront;
     }
 
+    /**
+     *  Get a const reference to the item at the front of the queue.
+     *  @return const-ref
+     */
     typename std::list<std::shared_ptr<T>>::const_reference front() const noexcept { return _q.front(); }
 
     /**
@@ -62,6 +110,11 @@ public:
     bool empty() const noexcept { return _q.empty(); }
 
 private:
+    /**
+     *  Because we need stable iterators, we chose an std::list
+     *  as the underlying datastructure.
+     *  @var std::list<std::shared_ptr<T>>
+     */
     std::list<std::shared_ptr<T>> _q;
 };
 

--- a/include/dnscpp/intrusivequeueitem.h
+++ b/include/dnscpp/intrusivequeueitem.h
@@ -1,35 +1,94 @@
+/**
+ *  intrusivequeueitem.h
+ *
+ *  Mixin class to allow removal from an IntrusiveQueue from anywhere
+ *  in the queue.
+ *
+ *  @author Raoul Wols <raoul.wols@copernica.com>
+ *  @copyright 2021 Copernica BV
+ */
+
+/**
+ *  Include guard
+ */
 #pragma once
 
+/**
+ *  Dependencies
+ */
 #include <list>
 #include <memory>
 
+/**
+ *  Begin namespace
+ */
 namespace DNS {
 
+/**
+ *  Class declaration
+ *  @tparam  T  The derived type (your class)
+ */
 template <class T>
 class IntrusiveQueueItem
 {
 private:
+
+    /**
+     *  The position in the queue. Because we need stable iterators,
+     *  we chose a list as the underlying data structure for the queue.
+     *  @var iterator
+     */
     typename std::list<std::shared_ptr<T>>::const_iterator _position;
+
+    /**
+     *  Whether this item is inserted into a queue
+     *  @var bool
+     */
     bool _hasposition = false;
 
 protected:
+    /**
+     *  Constructors are protected and copying is prohibited.
+     */
     IntrusiveQueueItem() = default;
     virtual ~IntrusiveQueueItem() noexcept = default;
     IntrusiveQueueItem(const IntrusiveQueueItem&) = delete;
     IntrusiveQueueItem& operator=(const IntrusiveQueueItem&) = delete;
 
 public:
+
+    /**
+     *  Whether this item is sitting in a queue.
+     *  @return bool
+     */
     bool hasposition() const noexcept { return _hasposition; }
+
+    /**
+     *  Get the iterator
+     *  @return iterator
+     */
     typename std::list<std::shared_ptr<T>>::const_iterator position() const noexcept { return _position; }
+
+    /**
+     *  Set the position in the queue.
+     *  @param  value  iterator
+     */
     void position(const typename std::list<std::shared_ptr<T>>::const_iterator &value)
     {
         _position = value;
         _hasposition = true;
     }
+
+    /**
+     *  Clear the position in the queue.
+     */
     void clearposition()
     {
         _hasposition = false;
     }
 };
 
+/**
+ *  End namespace DNS
+ */
 }

--- a/include/dnscpp/intrusivequeueitem.h
+++ b/include/dnscpp/intrusivequeueitem.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <list>
+#include <memory>
+
+namespace DNS {
+
+template <class T>
+class IntrusiveQueueItem
+{
+private:
+    typename std::list<std::shared_ptr<T>>::const_iterator _position;
+    bool _hasposition = false;
+
+protected:
+    IntrusiveQueueItem() = default;
+    virtual ~IntrusiveQueueItem() noexcept = default;
+    IntrusiveQueueItem(const IntrusiveQueueItem&) = delete;
+    IntrusiveQueueItem& operator=(const IntrusiveQueueItem&) = delete;
+
+public:
+    bool hasposition() const noexcept { return _hasposition; }
+    typename std::list<std::shared_ptr<T>>::const_iterator position() const noexcept { return _position; }
+    void position(const typename std::list<std::shared_ptr<T>>::const_iterator &value)
+    {
+        _position = value;
+        _hasposition = true;
+    }
+    void clearposition()
+    {
+        _hasposition = false;
+    }
+};
+
+}

--- a/include/dnscpp/lookup.h
+++ b/include/dnscpp/lookup.h
@@ -17,6 +17,7 @@
  *  Dependencies
  */
 #include "operation.h"
+#include "intrusivequeueitem.h"
 
 /**
  *  Begin of namespace
@@ -31,7 +32,7 @@ namespace DNS {
 /**
  *  Class definition
  */
-class Lookup : public Operation
+class Lookup : public Operation, public IntrusiveQueueItem<Lookup>
 {
 protected:
     /**
@@ -71,7 +72,14 @@ public:
      *  @return bool
      */
     virtual bool exhausted() const = 0;
-    
+
+    /**
+     *  Is this lookup expired: meaning did the lookup took too long
+     *  @param  double      current time
+     *  @return bool        true if it timed out
+     */
+    virtual bool expired(double now) const noexcept = 0;
+
     /**
      *  How long should we wait until the next runtime?
      *  @param  double      current time
@@ -95,6 +103,11 @@ public:
      *  @return bool        was a result reported to userspace?
      */
     virtual bool execute(double now) = 0;
+
+    /**
+     *  This lookup is done. Either it exhausted all of its attempts or it has a result. Invoke the callback handler
+     */
+    virtual void finalize() = 0;
 };
     
 /**

--- a/include/dnscpp/lookup.h
+++ b/include/dnscpp/lookup.h
@@ -88,19 +88,13 @@ public:
     virtual double delay(double now) const = 0;
     
     /**
-     *  Execute the next step in the lookup (for example to send out an extra datagram, or to report
-     *  a timeout back to userspace). This method returns true when indeed a call to userspace was
-     *  done during this call to execute(), and false if further processing is required.
-     * 
-     *  Note that a lookup can also finish via other execution paths too (for example in a method
-     *  that processes responses to UDP lookups). So you can not solely rely on the return value of
-     *  this method to find out if a lookup was finished, and you might need to call the finished()
-     *  method too to find this out. 
+     *  Execute this lookup.
      * 
      *  Watch out: this method should NOT be called when a lookup is already finished!!
+     *  or when it has no more attempts left
      * 
      *  @param  now         current time
-     *  @return bool        was a result reported to userspace?
+     *  @return bool        whether the execution succeeded
      */
     virtual bool execute(double now) = 0;
 

--- a/include/dnscpp/operation.h
+++ b/include/dnscpp/operation.h
@@ -94,7 +94,7 @@ public:
     }
     
     /**
-     *  Cancel the operation
+     *  Cancel the operation. Like all other possible callbacks, cancellation happens asynchronously.
      */
     virtual void cancel();
 };

--- a/include/dnscpp/operation.h
+++ b/include/dnscpp/operation.h
@@ -94,7 +94,8 @@ public:
     }
     
     /**
-     *  Cancel the operation. Like all other possible callbacks, cancellation happens asynchronously.
+     *  Cancel the operation. Calling this method results in your onCancelled callback to be invoked immediately.
+     *  Furthermore, this method is idempotent.
      */
     virtual void cancel();
 };

--- a/include/dnscpp/socket.h
+++ b/include/dnscpp/socket.h
@@ -81,10 +81,9 @@ protected:
 public:
     /**
      *  Invoke callback handlers for buffered raw responses
-     *  @param   maxcalls  the max number of callback handlers to invoke
      *  @return  number of callback handlers invoked
      */
-    virtual size_t deliver(size_t maxcalls);
+    virtual size_t deliver();
 
     /**
      *  Return true if there are buffered raw responses

--- a/include/dnscpp/sockets.h
+++ b/include/dnscpp/sockets.h
@@ -161,10 +161,9 @@ public:
 
     /**
      *  Deliver messages that have already been received and buffered to their appropriate processor
-     *  @param  size_t      max number of calls to userspace
      *  @return size_t      number of processed answers
      */
-    size_t deliver(size_t maxcalls);
+    size_t deliver();
 
     /**
      *  Is the socket now readable?

--- a/include/dnscpp/sockets.h
+++ b/include/dnscpp/sockets.h
@@ -157,7 +157,7 @@ public:
      *  @param  connector   the object interested in the connection
      *  @return bool
      */
-    bool connect(const Ip &ip, Connector *connector);
+    bool connect(const Ip &ip, std::shared_ptr<Connector> connector);
 
     /**
      *  Deliver messages that have already been received and buffered to their appropriate processor

--- a/include/dnscpp/tcp.h
+++ b/include/dnscpp/tcp.h
@@ -19,6 +19,7 @@
 #include <netinet/tcp.h>
 #include <unistd.h>
 #include <deque>
+#include <memory>
 #include "socket.h"
 #include "monitor.h"
 
@@ -106,7 +107,7 @@ private:
      *  Connectors that want to use this TCP socket for sending out a query
      *  @var std::deque
      */
-    std::deque<Connector *> _connectors;
+    std::deque<std::weak_ptr<Connector>> _connectors;
     
     /**
      *  Helper function to make a connection
@@ -186,7 +187,7 @@ public:
      *  @param  connector   the object that subscribes
      *  @return bool        was it possible to subscribe (not possible in failed state)
      */
-    bool subscribe(Connector *connector);
+    bool subscribe(std::shared_ptr<Connector> connector);
 
     /**
      *  The IP address to which this socket is connected

--- a/include/dnscpp/tcp.h
+++ b/include/dnscpp/tcp.h
@@ -204,10 +204,9 @@ public:
     /**
      *  Extended deliver() method (derives from the base class) that also takes the responsibility
      *  of passing the connection to the connectors.
-     *  @param  maxcalls    max number of calls to make
      *  @return size_t
      */
-    virtual size_t deliver(size_t maxcalls) override;
+    virtual size_t deliver() override;
 };
     
 /**

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -52,14 +52,14 @@ void Context::capacity(size_t value)
 Operation *Context::query(const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler)
 {
     // for A and AAAA lookups we also check the /etc/hosts file
-    if (type == ns_t_a    && _hosts.lookup(domain, 4)) return add(new LocalLookup(_hosts, domain, type, handler));
-    if (type == ns_t_aaaa && _hosts.lookup(domain, 6)) return add(new LocalLookup(_hosts, domain, type, handler));
+    if (type == ns_t_a    && _hosts.lookup(domain, 4)) return add(std::make_shared<LocalLookup>(_hosts, domain, type, handler));
+    if (type == ns_t_aaaa && _hosts.lookup(domain, 6)) return add(std::make_shared<LocalLookup>(_hosts, domain, type, handler));
     
     // the request can throw (for example when the domain is invalid
     try
     {
         // we are going to create a self-destructing request
-        return add(new RemoteLookup(this, domain, type, bits, handler));
+        return add(std::make_shared<RemoteLookup>(static_cast<Core*>(this), domain, type, bits, handler));
     }
     catch (...)
     {
@@ -78,7 +78,7 @@ Operation *Context::query(const char *domain, ns_type type, const Bits &bits, DN
 Operation *Context::query(const Ip &ip, const Bits &bits, DNS::Handler *handler)
 {
     // if the /etc/hosts file already holds a record
-    if (_hosts.lookup(ip)) return add(new LocalLookup(_hosts, ip, handler));
+    if (_hosts.lookup(ip)) return add(std::make_shared<LocalLookup>(_hosts, ip, handler));
 
     // pass on to the regular query method
     return query(Reverse(ip), TYPE_PTR, bits, handler);

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -258,14 +258,8 @@ void Core::expire()
 bool Core::finalize(const Watcher &watcher, std::shared_ptr<Lookup> &&lookup) const noexcept
 {
     // invoke callback handler
-    try
-    {
-        lookup->finalize();
-    }
-    catch (...)
-    {
-        // @todo: report/log this somehow?
-    }
+    lookup->finalize();
+
     // user-space might have destroyed us
     return !watcher.valid();
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -289,12 +289,12 @@ Inbound *Core::datagram(const Ip &ip, const Query &query)
  *  @param  connector   the object interested in the connection
  *  @return bool
  */
-bool Core::connect(const Ip &ip, Connector *connector)
+bool Core::connect(const Ip &ip, std::shared_ptr<Connector> connector)
 {
     // check the version number of ip
     switch (ip.version()) {
-    case 4:     return _ipv4.connect(ip, connector);
-    case 6:     return _ipv6.connect(ip, connector);
+    case 4:     return _ipv4.connect(ip, move(connector));
+    case 6:     return _ipv6.connect(ip, move(connector));
     default:    return false;
     }
 }    

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -227,7 +227,11 @@ void Core::expire()
     while (!_lookups.empty() && _lookups.front()->expired(now))
     {
         // if all attempts have been made, invoke user-space with a timeout
-        if (_lookups.front()->exhausted()) finalize(watcher, _lookups.pop());
+        if (_lookups.front()->exhausted())
+        {
+            // check if this resulted in `this` being destroyed
+            if (finalize(watcher, _lookups.pop())) return;
+        }
 
         // otherwise retry later
         else _scheduled.emplace_back(_lookups.pop());

--- a/src/locallookup.h
+++ b/src/locallookup.h
@@ -47,7 +47,7 @@ private:
      */
     virtual bool execute(double now) override
     {
-        // always fail
+        // always fail, because we want to be finalized
         return false;
     }
 
@@ -58,7 +58,7 @@ private:
      */
     virtual bool expired(double now) const noexcept override
     {
-        // we're always expired
+        // we're always expired, because we want to be finalized
         return true;
     }
 
@@ -100,7 +100,7 @@ private:
      */
     virtual bool exhausted() const override
     {
-        // put me in the ready queue immediately
+        // finalize me immediately
         return true;
     }
 

--- a/src/locallookup.h
+++ b/src/locallookup.h
@@ -51,6 +51,11 @@ private:
         return false;
     }
 
+    /**
+     *  Is this lookup expired: meaning did the lookup took too long
+     *  @param  double      current time
+     *  @return bool        true if it timed out
+     */
     virtual bool expired(double now) const noexcept override
     {
         // we're always expired

--- a/src/locallookup.h
+++ b/src/locallookup.h
@@ -37,10 +37,13 @@ private:
     const Hosts &_hosts;
     
     /**
-     *  Execute the lookup. Returns true when a user-space call was made, and false when further
-     *  processing is required.
+     *  Execute this lookup.
+     *
+     *  Watch out: this method should NOT be called when a lookup is already finished!!
+     *  or when it has no more attempts left
+     *
      *  @param  now         current time
-     *  @return bool        was there a call back to userspace?
+     *  @return bool        whether the execution succeeded
      */
     virtual bool execute(double now) override
     {

--- a/src/locallookup.h
+++ b/src/locallookup.h
@@ -44,19 +44,13 @@ private:
      */
     virtual bool execute(double now) override
     {
-        // do nothing if ready
-        assert(!finished());
+        // always fail
+        return false;
+    }
 
-        // remember the handler
-        auto *handler = _handler;
-        
-        // get rid of the handler to avoid that the result is reported
-        _handler = nullptr;
-
-        // pass to the hosts (this will trigger an immediate call to the handler)
-        _hosts.notify(Request(this), handler, this);
-        
-        // done
+    virtual bool expired(double now) const noexcept override
+    {
+        // we're always expired
         return true;
     }
 
@@ -98,8 +92,23 @@ private:
      */
     virtual bool exhausted() const override
     {
-        // handler is set on completion
-        return _handler == nullptr;
+        // put me in the ready queue immediately
+        return true;
+    }
+
+    virtual void finalize() override
+    {
+        // do nothing if ready
+        assert(!finished());
+
+        // remember the handler
+        auto *handler = _handler;
+
+        // get rid of the handler to avoid that the result is reported
+        _handler = nullptr;
+
+        // pass to the hosts (this will trigger an immediate call to the handler)
+        _hosts.notify(Request(this), handler, this);
     }
     
     /**

--- a/src/locallookup.h
+++ b/src/locallookup.h
@@ -96,6 +96,9 @@ private:
         return true;
     }
 
+    /**
+     *  Invoke callback handler
+     */
     virtual void finalize() override
     {
         // do nothing if ready

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -196,14 +196,14 @@ void RemoteLookup::report(const Response &response)
 {
     // for NXDOMAIN errors we need special treatment (maybe the hostname _does_ exists in
     // /etc/hosts?) For all other type of results the message can be passed to userspace
-    if (_response->rcode() != ns_r_nxdomain) return cleanup()->onReceived(this, *_response);
+    if (response.rcode() != ns_r_nxdomain) return cleanup()->onReceived(this, response);
 
     // extract the original question, to find out the host for which we were looking
-    Question question(*_response);
+    Question question(response);
 
     // there was a NXDOMAIN error, which we should not communicate if our /etc/hosts
     // file does have a record for this hostname, check this
-    if (!_core->exists(question.name())) return cleanup()->onReceived(this, *_response);
+    if (!_core->exists(question.name())) return cleanup()->onReceived(this, response);
 
     // get the original request (so that the response can match the request)
     Request request(this);

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -218,6 +218,9 @@ void RemoteLookup::report(const Response &response)
     cleanup()->onReceived(this, Response(fake.data(), fake.size()));
 }
 
+/**
+ *  Invoke callback handler
+ */
 void RemoteLookup::finalize()
 {
     // we MUST call back to user space exactly once, otherwise our promise is broken

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -226,7 +226,7 @@ void RemoteLookup::finalize()
         cleanup()->onCancelled(this);
     }
     // did we get a non-truncated response either via UDP or via TCP?
-    else if (_response)
+    else if (_response && !_response->truncated())
     {
         report(*_response);
     }

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -224,26 +224,16 @@ void RemoteLookup::finalize()
     assert(_handler);
 
     // were we cancelled?
-    if (_cancelled)
-    {
-        cleanup()->onCancelled(this);
-    }
+    if (_cancelled) cleanup()->onCancelled(this);
+
     // did we get a non-truncated response either via UDP or via TCP?
-    else if (_response && !_response->truncated())
-    {
-        report(*_response);
-    }
+    else if (_response && !_response->truncated()) report(*_response);
+
     // do we at least have the truncated response still?
-    else if (_truncated)
-    {
-        report(*_truncated);
-    }
+    else if (_truncated) report(*_truncated);
+
     // we must have exhausted all our attempts
-    else
-    {
-        // report a timeout
-        cleanup()->onTimeout(this);
-    }
+    else cleanup()->onTimeout(this);
 }
 
 /**

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -148,10 +148,13 @@ Handler *RemoteLookup::cleanup()
 }
 
 /**
- *  Execute the lookup. Returns true when a user-space call was made, and false when further
- *  processing is required.
+ *  Execute this lookup.
+ *
+ *  Watch out: this method should NOT be called when a lookup is already finished!!
+ *  or when it has no more attempts left
+ *
  *  @param  now         current time
- *  @return bool        was there a call back to userspace?
+ *  @return bool        whether the execution succeeded
  */
 bool RemoteLookup::execute(double now)
 {

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -262,7 +262,7 @@ bool RemoteLookup::onReceived(const Ip &ip, const Response &response)
     // when the response came from a TCP lookup and was still truncated (_truncated is used as a boolean to indicate tcp)
     // hence when _truncated evaluates to false, we try to connect to the nameserver via TCP. If that also fails,
     // we give up
-    if (!response.truncated() || _truncated || !_core->connect(ip, this))
+    if (!response.truncated() || _truncated || !_core->connect(ip, shared_from_this()))
     {
         // @todo: make Response movable
         _response.reset(new Response(response));

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -71,6 +71,7 @@ private:
 
     /**
      *  Was this lookup cancelled from userspace
+     *  @var bool
      */
     bool _cancelled = false;
 

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -81,6 +81,10 @@ private:
      */
     std::unique_ptr<Response> _truncated;
 
+    /**
+     *  The response from TCP mode, if we did that
+     *  @var std::unique_ptr<Response>
+     */
     std::unique_ptr<Response> _response;
     
     /**

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -42,7 +42,7 @@ class Inbound;
 /**
  *  Class definition
  */
-class RemoteLookup : public Lookup, public std::enable_shared_from_this<RemoteLookup>, private Processor, private Connector
+class RemoteLookup : public Lookup, public std::enable_shared_from_this<RemoteLookup>, private Processor, public Connector
 {
 private:
     /**

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -118,10 +118,13 @@ private:
     virtual bool onFailure(const Ip &ip) override;
 
     /**
-     *  Execute the lookup. Returns true when a user-space call was made, and false when further
-     *  processing is required.
+     *  Execute this lookup.
+     *
+     *  Watch out: this method should NOT be called when a lookup is already finished!!
+     *  or when it has no more attempts left
+     *
      *  @param  now         current time
-     *  @return bool        was there a call back to userspace?
+     *  @return bool        whether the execution succeeded
      */
     virtual bool execute(double now) override;
 

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -125,6 +125,9 @@ private:
      */
     virtual bool execute(double now) override;
 
+    /**
+     *  Invoke callback handler
+     */
     virtual void finalize() override;
 
     /**

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -61,19 +61,15 @@ void Socket::add(const Ip &addr, std::vector<unsigned char> &&buffer)
 /**
  *  Invoke callback handlers for buffered raw responses
  *  @param      watcher   The watcher to keep track if the parent object remains valid
- *  @param      maxcalls  The max number of callback handlers to invoke
  *  @return     number of callback handlers invoked
  */
-size_t Socket::deliver(size_t maxcalls)
+size_t Socket::deliver()
 {
     // the number of callback handlers invoked
     size_t result = 0;
     
-    // use a watcher in case object is destructed in the meantime
-    Watcher watcher(this);
-
     // look for a response
-    while (result < maxcalls && watcher.valid() && !_responses.empty())
+    while (!_responses.empty())
     {
         // avoid exceptions (parsing the response could fail)
         try

--- a/src/sockets.cpp
+++ b/src/sockets.cpp
@@ -151,7 +151,7 @@ Inbound *Sockets::datagram(const Ip &ip, const Query &query)
  *  @param  connector   the object interested in the connection
  *  @return bool
  */
-bool Sockets::connect(const Ip &ip, Connector *connector)
+bool Sockets::connect(const Ip &ip, std::shared_ptr<Connector> connector)
 {
     // check if we already have a connection to this ip
     for (auto &tcp : _tcps)
@@ -160,7 +160,7 @@ bool Sockets::connect(const Ip &ip, Connector *connector)
         if (tcp->ip() != ip) continue;
         
         // subscribe to the connection, so that it will be notified when ready
-        if (tcp->subscribe(connector)) return true;
+        if (tcp->subscribe(move(connector))) return true;
     }
     
     // avoid exceptions to bubble up
@@ -178,7 +178,7 @@ bool Sockets::connect(const Ip &ip, Connector *connector)
         // subscribe to the connection, so that it will be notified when ready (this
         // always returns true because we just created the object and it cannot yet
         // be in a failed state)
-        return tcp->subscribe(connector);
+        return tcp->subscribe(move(connector));
     }
     catch (...)
     {

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -207,7 +207,7 @@ void Tcp::upgrade()
     // can keep its internal counters of the number of running procedures up-to-date.
     // However, because we KNOW that _connector->onConnected() does not trigger any 
     // callbacks to user-space it is harmless and faster if we call that directly
-    for (auto *connector : _connectors) connector->onConnected(_ip, this);
+    for (auto &weakptr : _connectors) if (auto connector = weakptr.lock()) connector->onConnected(_ip, this);
     
     // reset the connectors
     _connectors.clear();
@@ -322,10 +322,13 @@ size_t Tcp::deliver()
     while (!_connectors.empty() && !connecting)
     {
         // get the oldest connector
-        auto *connector = _connectors.front();
-        
+        auto connector = _connectors.front().lock();
+
         // remove it from the vector
         _connectors.pop_front();
+
+        // is it still alive?
+        if (!connector) continue;
         
         // report the connection
         bool result = _connected ? connector->onConnected(_ip, this) : connector->onFailure(_ip);
@@ -348,7 +351,7 @@ size_t Tcp::deliver()
  * 
  *  @todo   make an unsubscribe() counter-part
  */
-bool Tcp::subscribe(Connector *connector)
+bool Tcp::subscribe(std::shared_ptr<Connector> connector)
 {
     // this is not possible if the connection is already in a failed state
     if (!_connected && _identifier == nullptr) return false;

--- a/test/stress.cpp
+++ b/test/stress.cpp
@@ -203,7 +203,7 @@ int main(int argc, char **argv)
     context.buffersize(1024 * 1024); // size of the input buffer (high lowers risk of package loss)
     context.interval(3.0);           // number of seconds until the datagram is retried (possibly to next server) (this does not cancel previous requests)
     context.attempts(3);             // number of attempts until failure / number of datagrams to send at most
-    context.capacity(256);           // max number of simultaneous lookups per dns-context (high increases speed but also risk of package-loss/servfails)
+    context.capacity(128);           // max number of simultaneous lookups per dns-context (high increases speed but also risk of package-loss/servfails)
     context.timeout(3.0);            // time to wait for a response after the _last_ attempt
     context.sockets(4);              // number of sockets
 


### PR DESCRIPTION
There is still the issue of lookups not getting resolved when the context is destroyed, however. But let's do that in another PR.

~~This is a work-in-progress.~~

Some nice goodies we have now:

- Bookkeeping of inflight requests is implicit by design
- Cancellations work correctly
- Cancellations are idempotent

Tested by running the `stress` executable. It randomly cancels some operations now. Also tested with random truncations.