### PR TITLE
Fixes project 38464

### DIFF
--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -304,7 +304,7 @@ public:
      *  @param  connector   the object interested in the connection
      *  @return bool
      */
-    bool connect(const Ip &ip, Connector *connector);
+    bool connect(const Ip &ip, std::shared_ptr<Connector> connector);
 
     /**
      *  Expose the nameservers

--- a/include/dnscpp/sockets.h
+++ b/include/dnscpp/sockets.h
@@ -157,7 +157,7 @@ public:
      *  @param  connector   the object interested in the connection
      *  @return bool
      */
-    bool connect(const Ip &ip, Connector *connector);
+    bool connect(const Ip &ip, std::shared_ptr<Connector> connector);
 
     /**
      *  Deliver messages that have already been received and buffered to their appropriate processor

--- a/include/dnscpp/tcp.h
+++ b/include/dnscpp/tcp.h
@@ -19,6 +19,7 @@
 #include <netinet/tcp.h>
 #include <unistd.h>
 #include <deque>
+#include <memory>
 #include "socket.h"
 #include "monitor.h"
 
@@ -106,7 +107,7 @@ private:
      *  Connectors that want to use this TCP socket for sending out a query
      *  @var std::deque
      */
-    std::deque<Connector *> _connectors;
+    std::deque<std::weak_ptr<Connector>> _connectors;
     
     /**
      *  Helper function to make a connection
@@ -186,7 +187,7 @@ public:
      *  @param  connector   the object that subscribes
      *  @return bool        was it possible to subscribe (not possible in failed state)
      */
-    bool subscribe(Connector *connector);
+    bool subscribe(std::shared_ptr<Connector> connector);
 
     /**
      *  The IP address to which this socket is connected

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -378,12 +378,12 @@ Inbound *Core::datagram(const Ip &ip, const Query &query)
  *  @param  connector   the object interested in the connection
  *  @return bool
  */
-bool Core::connect(const Ip &ip, Connector *connector)
+bool Core::connect(const Ip &ip, std::shared_ptr<Connector> connector)
 {
     // check the version number of ip
     switch (ip.version()) {
-    case 4:     return _ipv4.connect(ip, connector);
-    case 6:     return _ipv6.connect(ip, connector);
+    case 4:     return _ipv4.connect(ip, move(connector));
+    case 6:     return _ipv6.connect(ip, move(connector));
     default:    return false;
     }
 }

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -42,7 +42,7 @@ class Inbound;
 /**
  *  Class definition
  */
-class RemoteLookup : public Lookup, private Processor, private Connector
+class RemoteLookup : public Lookup, public std::enable_shared_from_this<RemoteLookup>, private Processor, public Connector
 {
 private:
     /**
@@ -62,7 +62,7 @@ private:
      *  @var size_t
      */
     size_t _id;
-    
+
     /**
      *  If we move to TCP modus because of truncation, we remember the truncated
      *  response in case the TCP attempt fails so that we can at least report something

--- a/src/sockets.cpp
+++ b/src/sockets.cpp
@@ -182,7 +182,7 @@ Inbound *Sockets::datagram(const Ip &ip, const Query &query)
  *  @param  connector   the object interested in the connection
  *  @return bool
  */
-bool Sockets::connect(const Ip &ip, Connector *connector)
+bool Sockets::connect(const Ip &ip, std::shared_ptr<Connector> connector)
 {
     // check if we already have a connection to this ip
     for (auto &tcp : _tcps)
@@ -191,7 +191,7 @@ bool Sockets::connect(const Ip &ip, Connector *connector)
         if (tcp->ip() != ip) continue;
         
         // subscribe to the connection, so that it will be notified when ready
-        if (tcp->subscribe(connector)) return true;
+        if (tcp->subscribe(move(connector))) return true;
     }
     
     // avoid exceptions to bubble up
@@ -209,7 +209,7 @@ bool Sockets::connect(const Ip &ip, Connector *connector)
         // subscribe to the connection, so that it will be notified when ready (this
         // always returns true because we just created the object and it cannot yet
         // be in a failed state)
-        return tcp->subscribe(connector);
+        return tcp->subscribe(move(connector));
     }
     catch (...)
     {


### PR DESCRIPTION
It can be the case that while we're connecting to the TCP socket the
Lookup might die in the meantime. The TCP socket kept a list of
"connectors" that it would inform when it was connected. This is now
a list of weak pointers to connectors to make sure that we're not
calling into dangling pointers.

This commit was cherry-picked from #29.