### PR TITLE
38483 retry on tcp connection lost

### DIFF
--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -221,10 +221,11 @@ protected:
     virtual ~Core();
 
     /**
-     *  Method that is called when a UDP socket has a buffer that it wants to deliver
+     *  Method that is called when a UDP socket has a buffer that it wants to deliver,
+     *  or is otherwise in need of action (like in a lost state)
      *  @param  sockets     the sockets with a buffer
      */
-    void onBuffered(Sockets *sockets) override;
+    void onActive(Sockets *sockets) override;
 
     /**
      *  Method that is called when a UDP socket has a buffer that it wants to deliver

--- a/include/dnscpp/inbound.h
+++ b/include/dnscpp/inbound.h
@@ -64,10 +64,11 @@ protected:
      */
     virtual ~Inbound() = default;
     
+    
     /**
      *  Method that is called when there are no more subscribers, and that 
      *  is implemented in the derived classes. Watch out: this method can be called
-     *  in the middle of loop through sockets so the implementation must be careful.
+     *  in the middle of loops through sockets so the implementation must be careful.
      */
     virtual void reset() = 0;
 

--- a/include/dnscpp/processor.h
+++ b/include/dnscpp/processor.h
@@ -31,6 +31,15 @@ public:
      *  @return bool
      */
     virtual bool onReceived(const Ip &ip, const Response &response) = 0;
+    
+    /**
+     *  Method that is called when an error occurs with the socket
+     *  This is used in case of TCP when a connection was suddenly lost
+     *  @param  ip          the ip from where the response came (nameserver ip)
+     *  @return bool
+     */
+    virtual bool onLost(const Ip &ip) = 0;
+    
 };
 
 /**

--- a/include/dnscpp/socket.h
+++ b/include/dnscpp/socket.h
@@ -38,10 +38,11 @@ public:
     {
     public:
         /**
-         *  Method that is invoked when this object has buffered responses available
+         *  Method that is invoked when this object has buffered responses 
+         *  available, or is otherwise active
          *  @param  socket      the reporting object
          */
-        virtual void onBuffered(Socket *socket) = 0;
+        virtual void onActive(Socket *socket) = 0;
     };
     
 protected:
@@ -84,13 +85,13 @@ public:
      *  @param   maxcalls  the max number of callback handlers to invoke
      *  @return  number of callback handlers invoked
      */
-    virtual size_t deliver(size_t maxcalls);
+    virtual size_t process(size_t maxcalls);
 
     /**
-     *  Return true if there are buffered raw responses
+     *  Return true if there are buffered raw responses or is otherwise active
      *  @return bool
      */
-    bool buffered() const noexcept { return !_responses.empty(); }
+    virtual bool active() const noexcept { return !_responses.empty(); }
 };
     
 /**

--- a/include/dnscpp/sockets.h
+++ b/include/dnscpp/sockets.h
@@ -61,7 +61,7 @@ public:
          *  Method that is called when one of the sockets has a buffer of received messages
          *  @param  udp     the reporting socket
          */
-        virtual void onBuffered(Sockets *udp) = 0;
+        virtual void onActive(Sockets *udp) = 0;
     };
     
 private:
@@ -99,10 +99,10 @@ private:
      *  This method is called when a socket has an inbound buffer that requires processing
      *  @param  socket  the reporting object
      */
-    virtual void onBuffered(Socket *socket) override 
+    virtual void onActive(Socket *socket) override 
     { 
         // pass on to the handler
-        _handler->onBuffered(this); 
+        _handler->onActive(this); 
     }
 
     /**
@@ -186,10 +186,10 @@ public:
      *  Does one of the sockets have an inbound buffer (meaning: is there a backlog of unprocessed messages?)
      *  @return bool
      */
-    bool buffered() const
+    bool active() const
     {
         // if there's a buffered response in one of the sockets then we consider ourselves buffered
-        for (const auto &sock : _udps) if (sock.buffered()) return true;
+        for (const auto &sock : _udps) if (sock.active()) return true;
 
         // otherwise we're not buffered
         return false;

--- a/include/dnscpp/tcp.h
+++ b/include/dnscpp/tcp.h
@@ -99,9 +99,14 @@ private:
     
     /**
      *  Is the socket already connected, or still in the process of being connected?
-     *  @var bool
+     *  @var enum
      */
-    bool _connected = false;
+    enum class State {
+        connecting,     // busy setting up a connection
+        failed,         // connection failure
+        connected,      // connected
+        lost,           // connection was lost in the middle of an operation
+    } _state = State::connecting;
 
     /**
      *  Connectors that want to use this TCP socket for sending out a query
@@ -132,8 +137,9 @@ private:
 
     /**
      *  Mark the connection as failed
+     *  @param  state       the new state
      */
-    void fail();
+    void fail(const State &state);
 
     /**
      *  The error state of the socket -- this can be used to check whether the socket is 
@@ -155,8 +161,8 @@ private:
 
     /**
      *  Check return value of a recv syscall
-     *  @param  bytes  The bytes transferred
-     *  @return true if we should leap out (an error occurred or we'd block), false if not
+     *  @param  bytes       The bytes transferred
+     *  @return boolean     True on success, false on failure (and we should leap out!)
      */
     bool updatetransferred(ssize_t bytes);
     
@@ -203,6 +209,7 @@ public:
 
     /**
      *  Send a full query
+     *  Note that this method can return nullptr in case the connection was already lost in the meantime
      *  @param  query       the query to send
      *  @return Inbound     the object that can be subscribed to for further processing
      */
@@ -214,7 +221,7 @@ public:
      *  @param  maxcalls    max number of calls to make
      *  @return size_t
      */
-    virtual size_t deliver(size_t maxcalls) override;
+    virtual size_t process(size_t maxcalls) override;
 };
     
 /**

--- a/src/connector.h
+++ b/src/connector.h
@@ -38,7 +38,7 @@ public:
     virtual bool onConnected(const Ip &ip, Tcp *tcp) = 0;
     
     /**
-     *  Called when the connection could not be set up
+     *  Called when the connection could not be set up (server unreachable)
      *  @param  ip          ip to which a connection was set up
      *  @return bool        was there a call back to userspace?
      */

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -164,7 +164,7 @@ Operation *Core::add(Lookup *lookup)
 double Core::delay(double now)
 {
     // if there is an unprocessed inbound queue, we have to expire asap
-    if (_ipv4.buffered() || _ipv6.buffered()) return 0.0;
+    if (_ipv4.active() || _ipv6.active()) return 0.0;
     
     // if there is nothing scheduled
     if (_lookups.empty() && _ready.empty()) return -1.0;
@@ -211,7 +211,7 @@ void Core::reschedule(double now)
  *  Method that is called when a UDP socket has a buffer that it wants to deliver
  *  @param  sockets     the sockets with a buffer
  */
-void Core::onBuffered(Sockets *sockets)
+void Core::onActive(Sockets *sockets)
 {
     // if we already had an immediate timer we do not have to set it
     if (_timer != nullptr && _immediate) return;

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -309,7 +309,7 @@ bool RemoteLookup::onLost(const Ip &ip)
     if (_connecting == nullptr) return report(*_truncated);
 
     // one extra tcp connection is in progress
-    _connections = 1;
+    _connections += 1;
     
     // the connection is in progress, and not call to userspace was made yet
     return false;

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -94,6 +94,13 @@ private:
     virtual bool onReceived(const Ip &ip, const Response &response) override;
 
     /**
+     *  Called when a TCP connection was lost in the middle of an operation
+     *  @param  ip          ip to which the connection was set up
+     *  @return bool        was there a call to userspace?
+     */
+    virtual bool onLost(const Ip &ip) override;
+
+    /**
      *  Called when a TCP connection has been set up (in case an earlier UDP response was truncated)
      *  @param  ip          ip to which a connection was set up
      *  @param  tcp         the actual TCP connection

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -53,10 +53,16 @@ private:
     double _last = 0.0;
     
     /**
-     *  Number of messages that have already been sent
+     *  Number of datagram messages that have already been sent
      *  @var size_t
      */
-    size_t _count = 0;
+    size_t _datagrams = 0;
+    
+    /**
+     *  Number of TCP connections that have been set up
+     *  @var size_t
+     */
+    size_t _connections = 0;
     
     /**
      *  Random ID (mainly used to decide which nameserver to use first)

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -41,7 +41,7 @@ void Socket::add(const sockaddr *addr, std::vector<unsigned char> &&buffer)
     }
 
     // reschedule the processing of messages
-    _handler->onBuffered(this);
+    _handler->onActive(this);
 }
 
 /**
@@ -55,7 +55,7 @@ void Socket::add(const Ip &addr, std::vector<unsigned char> &&buffer)
     _responses.emplace_back(addr, move(buffer));
 
     // reschedule the processing of messages
-    _handler->onBuffered(this);
+    _handler->onActive(this);
 }
 
 /**
@@ -64,7 +64,7 @@ void Socket::add(const Ip &addr, std::vector<unsigned char> &&buffer)
  *  @param      maxcalls  The max number of callback handlers to invoke
  *  @return     number of callback handlers invoked
  */
-size_t Socket::deliver(size_t maxcalls)
+size_t Socket::process(size_t maxcalls)
 {
     // the number of callback handlers invoked
     size_t result = 0;

--- a/src/sockets.cpp
+++ b/src/sockets.cpp
@@ -89,7 +89,7 @@ size_t Sockets::deliver(size_t maxcalls)
     for (auto &socket : _udps)
     {
         // pass the buffered responses to the lookup objects
-        result += socket.deliver(maxcalls);
+        result += socket.process(maxcalls);
         
         // update number of calls
         maxcalls -= result;
@@ -113,7 +113,7 @@ size_t Sockets::deliver(size_t maxcalls)
     for (auto &socket : sockets)
     {
         // pass the buffered responses to the lookup objects
-        result += socket->deliver(maxcalls);
+        result += socket->process(maxcalls);
         
         // update number of calls
         maxcalls -= result;

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -250,7 +250,7 @@ bool Tcp::updatetransferred(ssize_t result)
 
     // if there is a failure we leap out as well
     if (result <= 0) return fail(State::lost), false;
-
+    
     // update the number of transferred bytes
     _transferred += result;
 
@@ -280,7 +280,7 @@ void Tcp::notify()
         const auto result = ::recv(_fd, (uint8_t*)&_size + _transferred, sizeof(uint16_t) - _transferred, MSG_DONTWAIT);
 
         // if there is a failure we leap out
-        if (updatetransferred(result)) return;
+        if (!updatetransferred(result)) return;
 
         // if we still haven't received the two bytes we should leap out here
         if (_transferred < sizeof(uint16_t)) return;

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -14,6 +14,7 @@
 #include "../include/dnscpp/loop.h"
 #include "../include/dnscpp/query.h"
 #include "../include/dnscpp/watcher.h"
+#include "../include/dnscpp/processor.h"
 #include "blocking.h"
 #include "connector.h"
 
@@ -155,6 +156,9 @@ Inbound *Tcp::send(const Query &query)
     // We MUST avoid having duplicate ID's that are active on the same connection,
     // for example by delaying queries with identical ids until earlier queries are ready
     
+    // if the connection was already lost in the meantime
+    if (_state != State::connected) return nullptr;
+    
     // make the socket blocking
     Blocking blocking(_fd);
     
@@ -194,10 +198,10 @@ size_t Tcp::expected() const
 void Tcp::upgrade()
 {
     // is the socket now connected?
-    _connected = error() == 0;
+    if (error() != 0) return fail(State::failed);
     
-    // if the connection failed
-    if (!_connected) return fail();
+    // the connection succeeded
+    _state = State::connected;
 
     // we no longer monitor for writability, but for readability instead
     _loop->update(_identifier, _fd, 1, this);
@@ -215,8 +219,9 @@ void Tcp::upgrade()
 
 /**
  *  Mark the connection as failed
+ *  @param  state       the new state
  */
-void Tcp::fail()
+void Tcp::fail(const State &state)
 {
     // we can stop monitoring the socket
     _loop->remove(_identifier, _fd, this); 
@@ -224,33 +229,33 @@ void Tcp::fail()
     // reset the identifier
     _identifier = nullptr;
     
-    // object is no longer connected
-    _connected = false;
+    // update the state
+    _state = state;
 
-    // we connectors should be notified about the failure, but we postpone that so that
-    // it can be triggered from the Core class via call to deliver() (so that Core can keep
+    // the connectors should be notified about the failure, but we postpone that so that
+    // it can be triggered from the Core class via call to process() (so that Core can keep
     // all its timers up-to-date)
-    _handler->onBuffered(this);
+    _handler->onActive(this);
 }
 
 /**
  *  Check return value of a recv syscall
- *  @param  bytes  The bytes transferred
- *  @return true if we should leap out (an error occurred), false if not
+ *  @param  bytes       The bytes transferred
+ *  @return boolean     True on success, false on failure (and we should leap out!)
  */
 bool Tcp::updatetransferred(ssize_t result)
 {
-    // the operation would block, but don't leap out
-    if (result < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return false;
+    // the operation can block, this is ok
+    if (result < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return true;
 
     // if there is a failure we leap out as well
-    if (result <= 0) return fail(), true;
+    if (result <= 0) return fail(State::lost), false;
 
     // update the number of transferred bytes
     _transferred += result;
 
     // don't leap out
-    return false;
+    return true;
 }
 
 /**
@@ -263,7 +268,7 @@ void Tcp::notify()
     // we SHOULD retry the TCP requests
     
     // if the socket is not yet connected, it might be connected right now
-    if (!_connected) return upgrade();
+    if (_state == State::connecting) return upgrade();
 
     // We can be in two receive states: the first state is that we're waiting for the
     // size of the buffer. The second state is that we are waiting for the response content itself.
@@ -271,13 +276,14 @@ void Tcp::notify()
     // If that's less than 2 then we're still waiting for the response size.
     if (_transferred < sizeof(uint16_t))
     {
+        // read one or two bytes into the _size variable
         const auto result = ::recv(_fd, (uint8_t*)&_size + _transferred, sizeof(uint16_t) - _transferred, MSG_DONTWAIT);
 
         // if there is a failure we leap out
         if (updatetransferred(result)) return;
 
         // if we still haven't received the two bytes we should leap out here
-        else if (_transferred < sizeof(uint16_t)) return;
+        if (_transferred < sizeof(uint16_t)) return;
 
         // OK: the size of the rest of the frame was received, we know how much to allocate
         // update the size
@@ -293,7 +299,7 @@ void Tcp::notify()
     // This is the second state of the Tcp state machine. At this point we know we have
     // received at least two bytes of the frame, and so we know we have resized the
     // buffer accordingly. All that's left to do is to await the full response content
-    if (updatetransferred(::recv(_fd, _buffer.data() + offset, _buffer.size() - offset, MSG_DONTWAIT))) return;
+    if (!updatetransferred(::recv(_fd, _buffer.data() + offset, _buffer.size() - offset, MSG_DONTWAIT))) return;
 
     // continue waiting if we have not yet received everything there is
     if (expected() > 0) return;
@@ -311,7 +317,7 @@ void Tcp::notify()
  *  @param      maxcalls  The max number of callback handlers to invoke
  *  @return     number of callback handlers invoked
  */
-size_t Tcp::deliver(size_t maxcalls)
+size_t Tcp::process(size_t maxcalls)
 {
     // the object could destruct in the meantime, because there are call to userspace
     Watcher watcher(this);
@@ -319,11 +325,8 @@ size_t Tcp::deliver(size_t maxcalls)
     // number of calls made
     size_t calls = 0;
     
-    // is the object still busy connecting?
-    bool connecting = !_connected && _identifier != nullptr;
-    
-    // inform them all
-    while (calls < maxcalls && !_connectors.empty() && !connecting)
+    // inform all connectors that the socket became connected or that the connection failed
+    while (calls < maxcalls && !_connectors.empty() && _state != State::connecting)
     {
         // get the oldest connector
         auto *connector = _connectors.front();
@@ -331,21 +334,55 @@ size_t Tcp::deliver(size_t maxcalls)
         // remove it from the vector
         _connectors.pop_front();
         
-        // report the connection
-        bool result = _connected ? connector->onConnected(_ip, this) : connector->onFailure(_ip);
+        // report the connection (note that it is technically possible (but unlikely) that the socket is 
+        // already in a lost state by now, but we still report it as 'connected', which has the consequence
+        // that callers might use this socket to send out messages anyway, so they should check the return
+        // value of the send() method)
+        bool result = _state == State::failed ? connector->onFailure(_ip) : connector->onConnected(_ip, this);
         
-        // update the counter
-        if (result) calls += 1;
+        // if there was no call to user-space we can proceed (`this` cannot be destructed)
+        if (!result) continue;
+        
+        // update bookkeeping
+        calls += 1;
+        
+        // stop if userspace destructed us
+        if (!watcher.valid()) return calls;
+    }
+
+    // call base to deliver buffered responses to the lookups
+    calls += Socket::process(maxcalls - calls);
+
+    // stop if userspace destructed us
+    if (!watcher.valid()) return calls;
+
+    // if the connection was lost while we have subscribers, we notify them as well
+    while (maxcalls > calls && _state == State::lost && !_processors.empty())
+    {
+        // front of the set
+        auto iter = _processors.begin();
+        
+        // get the oldest processor
+        auto *processor = std::get<2>(*iter);
+        
+        // remove from the set
+        _processors.erase(iter);
+        
+        // notify the processor
+        if (!processor->onLost(_ip)) continue;
+        
+        // update bookkeeping
+        calls += 1;
         
         // stop if userspace destructed us
         if (!watcher.valid()) return calls;
     }
     
-    // if there are no more connectors (and also no subscribers) this connection can be removed
-    if (_connectors.empty()) reset();
+    // check if the socket is unused now (our reset() method has some safety checks)
+    reset();
     
-    // call base
-    return calls + Socket::deliver(maxcalls - calls);
+    // done
+    return calls;
 }
 
 /**
@@ -355,18 +392,20 @@ size_t Tcp::deliver(size_t maxcalls)
  */
 Connecting *Tcp::subscribe(Connector *connector)
 {
-    // this is not possible if the connection is already in a failed state
-    if (!_connected && _identifier == nullptr) return nullptr;
+    // this is not possible if the connection is already in a failed state (in all other
+    // cases (even state_lost!) subscribing is possible and will eventually result in a call 
+    // to either onConnected() or onFailed())
+    if (_state == State::failed) return nullptr;
     
     // add the connector to be notified later when the connection is available
     _connectors.push_back(connector);
     
     // in case we're not yet connected we already wait for the connection to be ready,
     // and when we already have connectors, the parent was already informed
-    if (!_connected || _connectors.size() > 1) return this;
+    if (_state == State::connecting || _connectors.size() > 1) return this;
     
     // notify the parent that there are actions to be performed
-    _handler->onBuffered(this);
+    _handler->onActive(this);
     
     // report success
     return this;
@@ -381,14 +420,8 @@ void Tcp::unsubscribe(Connector *connector)
     // remove the connector from the vector
     _connectors.erase(std::remove(_connectors.begin(), _connectors.end(), connector), _connectors.end());
     
-    // if the socket is unused by now, we have to inform our parent
-    if (!_connectors.empty() || subscribers() > 0) return;
-    
-    // there are no more subscribers, we are going to tell the parent about it
-    auto *handler = (Tcp::Handler *)_handler;
-    
-    // notify our parent (note that this will immediately destruct `this`)
-    handler->onUnused(this);
+    // check if the socket is unused now (our reset() method has some safety checks)
+    reset();
 }
 
 /**


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc7766#section-6.2.4

DNS clients should retry if the DNS server closes the connection. This has now been implemented in DNS-CPP.