### PR TITLE
Ensure unique query ids for TCP connections

### DIFF
--- a/include/dnscpp/query.h
+++ b/include/dnscpp/query.h
@@ -16,6 +16,7 @@
  *  Dependencies
  */
 #include <arpa/nameser.h>
+#include <array>
 #include <stdint.h>
 #include "bits.h"
 
@@ -46,7 +47,7 @@ private:
      *  Buffer that is big enough to hold the entire query
      *  @var unsigned char[]
      */
-    unsigned char _buffer[HFIXEDSZ + QFIXEDSZ + MAXCDNAME + 1];
+    std::array<unsigned char, HFIXEDSZ + QFIXEDSZ + MAXCDNAME + 1> _buffer;
     
     /**
      *  Size of the buffer
@@ -61,7 +62,7 @@ private:
      */
     unsigned char *end()
     {
-        return _buffer + _size;
+        return _buffer.data() + _size;
     }
 
     /**
@@ -70,7 +71,7 @@ private:
      */
     const unsigned char *end() const
     {
-        return _buffer + _size;
+        return _buffer.data() + _size;
     }
     
     /**
@@ -79,7 +80,7 @@ private:
      */
     size_t remaining() const
     {
-        return sizeof(_buffer) - _size;
+        return _buffer.size() - _size;
     }
     
     /**
@@ -139,13 +140,6 @@ public:
     Query(int op, const char *dname, int type, const Bits &bits, const unsigned char *data = nullptr);
 
     /**
-     *  No copying (disabled because copying is expensive and we want the compiler
-     *  to warn is in case we accidentally do rely on a copy-operation)
-     *  @param that
-     */
-    Query(const Query &that) = delete;
-    
-    /**
      *  Destructor
      */
     virtual ~Query() noexcept = default;
@@ -154,7 +148,7 @@ public:
      *  The internal raw binary data
      *  @return const unsigned char *
      */
-    const unsigned char *data() const noexcept { return _buffer; }
+    const unsigned char *data() const noexcept { return _buffer.data(); }
     
     /**
      *  Size of the request

--- a/include/dnscpp/socket.h
+++ b/include/dnscpp/socket.h
@@ -58,6 +58,12 @@ private:
      */
     std::list<std::pair<Ip,std::vector<unsigned char>>> _responses;
 
+    /**
+     *  A response payload was received with this ID
+     *  @param  id    The identifier
+     */
+    virtual void onReceivedId(uint16_t id) {};
+
 protected:
     /**
      *  Constructor

--- a/include/dnscpp/tcp.h
+++ b/include/dnscpp/tcp.h
@@ -112,10 +112,10 @@ private:
     std::set<uint16_t> _queryids;
 
     /**
-     *  Queries awaiting to be sent over wire, but had an ID collision with one that is already in flight
-     *  @var std::map
+     *  Queries awaiting to be sent over the wire, but had an ID collision with one that is already in flight
+     *  @var std::multimap
      */
-    std::map<uint16_t, std::list<Query>> _awaiting;
+    std::multimap<uint16_t, Query> _awaiting;
 
     /**
      *  Connectors that want to use this TCP socket for sending out a query

--- a/include/dnscpp/tcp.h
+++ b/include/dnscpp/tcp.h
@@ -21,7 +21,6 @@
 #include <deque>
 #include <map>
 #include <set>
-#include <functional>
 #include "socket.h"
 #include "monitor.h"
 #include "connecting.h"
@@ -116,7 +115,7 @@ private:
      *  Queries awaiting to be sent over wire, but had an ID collision with one that is already in flight
      *  @var std::map
      */
-    std::map<uint16_t, std::list<std::reference_wrapper<const Query>>> _awaiting;
+    std::map<uint16_t, std::list<Query>> _awaiting;
 
     /**
      *  Connectors that want to use this TCP socket for sending out a query
@@ -231,8 +230,7 @@ public:
 
     /**
      *  Send a full query
-     *  @param  query       the query to send. You must ensure the address of this variable stays
-     *                      valid in memory until a response is received.
+     *  @param  query       the query to send
      *  @return Inbound     the object that can be subscribed to for further processing
      */
     Inbound *send(const Query &query);

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -92,6 +92,9 @@ size_t Socket::deliver(size_t maxcalls)
             // parse the response
             Response response(front.second.data(), front.second.size());
 
+            // make it known that this ID is now free to use
+            onReceivedId(response.id());
+
             // filter on the response, the beginning is simply the handler at nullptr
             auto begin = _processors.lower_bound(std::make_tuple(response.id(), front.first, nullptr));
 

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -356,6 +356,9 @@ void Tcp::notify()
  */
 void Tcp::onReceivedId(uint16_t id)
 {
+    // leap out if we're in the failure state
+    if (!_connected && _identifier == nullptr) return;
+
     // find the list of queries that are awaiting to be sent
     auto iter = _awaiting.find(id);
 

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -163,14 +163,12 @@ Inbound *Tcp::send(const Query &query)
         // send it after all, we'll enter the `fail()` method.
         return this;
     }
-    else
-    {
-        // this query is not inflight, let's remember that it is in fact in flight
-        _queryids.insert(query.id());
-    }
 
-    // send it over the wire
-    return sendimpl(query);
+    // this query is not inflight, let's remember that it is in fact in flight (if it succeeds)
+    if (auto *inbound = sendimpl(query)) return _queryids.insert(query.id()), inbound;
+
+    // we failed
+    return nullptr;
 }
 
 /**

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -177,8 +177,8 @@ Inbound *Tcp::send(const Query &query)
             iter->second.push_back(query);
         }
 
-        // we'll pretend everything went OK
-        // @todo: what if later it turns out that we couldn't send it?
+        // We'll pretend everything went OK. If it later turns out we couldn't
+        // send it after all, we'll enter the `fail()` method.
         return this;
     }
     else


### PR DESCRIPTION
Duplicate query IDs are temporarily stored in a map and are sent
once the in-use ID is freed.

If the connection is broken for whatever reason, we enter the
fail() method which notifies all interested parties to drop their
request handlers.