### PR TITLE
added search path parsing, and exposed methods for search path

### DIFF
--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -67,6 +67,12 @@ protected:
      *  @var std::vector<Ip>
      */
     std::vector<Ip> _nameservers;
+
+    /**
+     *  The IP addresses of the servers that can be accessed
+     *  @var std::vector<Ip>
+     */
+    std::vector<const char *> _searchpaths;
     
     /**
      *  The contents of the /etc/hosts file

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -72,7 +72,7 @@ protected:
      *  The IP addresses of the servers that can be accessed
      *  @var std::vector<Ip>
      */
-    std::vector<const char *> _searchpaths;
+    std::vector<std::string> _searchpaths;
     
     /**
      *  The contents of the /etc/hosts file

--- a/include/dnscpp/resolvconf.h
+++ b/include/dnscpp/resolvconf.h
@@ -147,7 +147,7 @@ public:
      *  @param  index
      *  @return const char *
      */
-    const char *searchpath(size_t index) const { return _searchpaths[index]; }
+    std::string searchpath(size_t index) const { return _searchpaths[index]; }
 
     /**
      *  Whether or not the 'rotate' option is set in the resolve conf

--- a/include/dnscpp/resolvconf.h
+++ b/include/dnscpp/resolvconf.h
@@ -38,6 +38,12 @@ private:
     std::vector<Ip> _nameservers;
 
     /**
+     *  The detected search paths
+     *  @var std::vector<std::string>
+     */
+    std::vector<const char *> _searchpaths;
+
+    /**
      *  Timeout as specified in the conf (this is the interval between attempts)
      *  @var size_t
      */
@@ -129,6 +135,19 @@ public:
      *  @return Ip
      */
     const Ip &nameserver(size_t index) const { return _nameservers[index]; }
+
+    /**
+     *  Number of searchpaths
+     *  @return size_t
+     */
+    size_t searchpaths() const { return _nameservers.size(); }
+
+    /**
+     *  Get a specific search path
+     *  @param  index
+     *  @return const char *
+     */
+    const char *searchpath(size_t index) const { return _searchpaths[index]; }
 
     /**
      *  Whether or not the 'rotate' option is set in the resolve conf

--- a/include/dnscpp/resolvconf.h
+++ b/include/dnscpp/resolvconf.h
@@ -140,7 +140,7 @@ public:
      *  Number of searchpaths
      *  @return size_t
      */
-    size_t searchpaths() const { return _nameservers.size(); }
+    size_t searchpaths() const { return _searchpaths.size(); }
 
     /**
      *  Get a specific search path

--- a/include/dnscpp/resolvconf.h
+++ b/include/dnscpp/resolvconf.h
@@ -41,7 +41,7 @@ private:
      *  The detected search paths
      *  @var std::vector<std::string>
      */
-    std::vector<const char *> _searchpaths;
+    std::vector<std::string> _searchpaths;
 
     /**
      *  Timeout as specified in the conf (this is the interval between attempts)

--- a/include/dnscpp/resolvconf.h
+++ b/include/dnscpp/resolvconf.h
@@ -154,7 +154,7 @@ public:
      *  @param  index
      *  @return const char *
      */
-    std::string searchpath(size_t index) const { return _searchpaths[index]; }
+    const std::string &searchpath(size_t index) const { return _searchpaths[index]; }
 
     /**
      *  Whether or not the 'rotate' option is set in the resolve conf

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -43,7 +43,7 @@ void Context::capacity(size_t value)
 
 /**
  *  Do a dns lookup
- *  @param  name        the record name to look for
+ *  @param  domain      the record name to look for
  *  @param  type        type of record (normally you ask for an 'a' record)
  *  @param  bits        bits to include in the query
  *  @param  handler     object that will be notified when the query is ready

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -40,6 +40,8 @@ Core::Core(Loop *loop, bool defaults) :
     
     // copy the nameservers
     for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(settings.nameserver(i));
+    // copy the search paths
+    for (size_t i = 0; i < settings.searchpaths(); ++i) _searchpaths.emplace_back(settings.searchpath(i));
     
     // take over some of the settings
     _timeout = settings.timeout();
@@ -64,6 +66,8 @@ Core::Core(Loop *loop, const ResolvConf &settings) :
 {
     // construct the nameservers
     for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(settings.nameserver(i));
+    // construct the search paths
+    for (size_t i = 0; i < settings.searchpaths(); ++i) _searchpaths.emplace_back(settings.searchpath(i));
 
     // take over some of the settings
     _timeout = settings.timeout();

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -63,9 +63,8 @@ Core::Core(Loop *loop, const ResolvConf &settings) :
     _ipv4(loop, this),
     _ipv6(loop, this)
 {
-    // construct the nameservers
+    // construct the nameservers and search paths
     for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(settings.nameserver(i));
-    // construct the search paths
     for (size_t i = 0; i < settings.searchpaths(); ++i) _searchpaths.emplace_back(settings.searchpath(i));
 
     // take over some of the settings

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -38,9 +38,8 @@ Core::Core(Loop *loop, bool defaults) :
     // load the defaults from /etc/resolv.conf
     ResolvConf settings;
     
-    // copy the nameservers
+    // copy the nameservers and search paths
     for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(settings.nameserver(i));
-    // copy the search paths
     for (size_t i = 0; i < settings.searchpaths(); ++i) _searchpaths.emplace_back(settings.searchpath(i));
     
     // take over some of the settings

--- a/src/resolvconf.cpp
+++ b/src/resolvconf.cpp
@@ -164,8 +164,18 @@ void ResolvConf::domain(const char *line, size_t size)
  */
 void ResolvConf::search(const char *line, size_t size)
 {
-    // add search path
-    _searchpaths.emplace_back(line);
+    // we dont know if its terminated, so we wrap it in a string
+    std::string searchline(line, size);
+    // we tokenize the string (note that this replaces spaces with null terminators)
+    auto tokens = strtok(&searchline[0], " ");
+    // so long as there are tokens
+    while (tokens != nullptr)
+    {
+        // store the (now terminated) searchpath
+        _searchpaths.emplace_back(tokens);
+        // next token
+        tokens = strtok(nullptr, " ");
+    }
 }
 
 /**

--- a/src/resolvconf.cpp
+++ b/src/resolvconf.cpp
@@ -164,8 +164,8 @@ void ResolvConf::domain(const char *line, size_t size)
  */
 void ResolvConf::search(const char *line, size_t size)
 {
-    // report error
-    throw std::runtime_error(std::string("not implemented: search ") + line);
+    // add search path
+    _searchpaths.emplace_back(line);
 }
 
 /**

--- a/src/resolvconf.cpp
+++ b/src/resolvconf.cpp
@@ -164,17 +164,31 @@ void ResolvConf::domain(const char *line, size_t size)
  */
 void ResolvConf::search(const char *line, size_t size)
 {
+    // we only remember the last entry, so we remove potential previous entries
+    _searchpaths.clear();
     // we dont know if its terminated, so we wrap it in a string
-    std::string searchline(line, size);
-    // we tokenize the string (note that this replaces spaces with null terminators)
-    auto tokens = strtok(&searchline[0], " ");
-    // so long as there are tokens
-    while (tokens != nullptr)
+    std::string source(line, size);
+
+    // create some helper variables
+    size_t prev = 0;
+    size_t next = 0;
+    // while we keep finding spaces or tabs
+    while ((next = source.find_first_of(" \t", prev)) != std::string::npos)
     {
-        // store the (now terminated) searchpath
-        _searchpaths.emplace_back(tokens);
-        // next token
-        tokens = strtok(nullptr, " ");
+        // if the size of the sub-section > 0
+        if (next - prev != 0)
+        {
+            // store the result
+            _searchpaths.emplace_back(source.substr(prev, next - prev));
+        }
+        // search again starting from the last match
+        prev = next + 1;
+    }
+    // if there is part of the line left without a space
+    if (prev < source.size())
+    {
+        // add it
+        _searchpaths.push_back(source.substr(prev));
     }
 }
 


### PR DESCRIPTION
This library does not support "search" lines in resolv.conf. ignoring them silencely unless strict mode is on.

In this pull request we just parse the search entries.
In later commits i will add the functionality to actually use the search entries in dns lookups.