### PR TITLE
Now respects search path when performing dns querys

### DIFF
--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -31,6 +31,7 @@ namespace DNS {
  */
 class Handler;
 class Operation;
+class SearchLookupHandler;
 
 /**
  *  Class definition
@@ -67,7 +68,7 @@ public:
     /**
      *  Destructor
      */
-    virtual ~Context() = default;
+    virtual ~Context();
     
     /**
      *  Clear the list of nameservers
@@ -177,7 +178,7 @@ public:
      */
     Operation *query(const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler);
     Operation *query(const char *domain, ns_type type, DNS::Handler *handler) { return query(domain, type, _bits, handler); }
-    
+
     /**
      *  Do a reverse IP lookup, this is only meaningful for PTR lookups
      *  @param  ip          the ip address to lookup

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -68,7 +68,7 @@ public:
     /**
      *  Destructor
      */
-    virtual ~Context();
+    virtual ~Context() = default;
     
     /**
      *  Clear the list of nameservers

--- a/include/dnscpp/lookup.h
+++ b/include/dnscpp/lookup.h
@@ -36,6 +36,12 @@ class Lookup : public Operation
 {
 protected:
     /**
+     *  The core object
+     *  @var Core
+     */
+    Core *_core;
+
+    /**
      *  Constructor
      *  @param  core        the core object
      *  @param  handler     user space handler
@@ -47,7 +53,8 @@ protected:
      *  @throws std::runtime_error
      */
     Lookup(Core *core, Handler *handler, int op, const char *dname, int type, const Bits &bits, const unsigned char *data = nullptr) :
-        Operation(core, handler, op, dname, type, bits, data) {}
+        Operation(handler, op, dname, type, bits, data),
+        _core(core) {}
 
 public:
     /**

--- a/include/dnscpp/operation.h
+++ b/include/dnscpp/operation.h
@@ -39,12 +39,6 @@ class Operation
 {
 protected:
     /**
-     *  The core object
-     *  @var Core
-     */
-    Core *_core;
-
-    /**
      *  The user-space handler (this is set to nullptr when the result has been reported to userspace)
      *  @var Handler
      */
@@ -66,8 +60,9 @@ protected:
      *  @param  data        optional data (only for type = ns_o_notify)
      *  @throws std::runtime_error
      */
-    Operation(Core *core, Handler *handler, int op, const char *dname, int type, const Bits &bits, const unsigned char *data = nullptr) :
-        _core(core), _handler(handler), _query(op, dname, type, bits, data) {}
+    Operation(Handler *handler, int op, const char *dname, int type, const Bits &bits, const unsigned char *data = nullptr) :
+        _handler(handler), 
+        _query(op, dname, type, bits, data) {}
 
     /**
      *  Private destructor because userspace is not supposed to destruct this

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -14,7 +14,6 @@
 #include "remotelookup.h"
 #include "locallookup.h"
 #include "idgenerator.h"
-#include <iostream>
 #include "searchlookuphandler.h"
 
 /**
@@ -68,7 +67,6 @@ Operation *Context::query(const char *domain, ns_type type, const Bits &bits, DN
         // return the searchlookuphandler, that will try every search-path one by one
         return new SearchLookupHandler(_searchpaths, this, type, bits, domain, handler);
     }
-    
 
     // for A and AAAA lookups we also check the /etc/hosts file
     if (type == ns_t_a    && _hosts.lookup(domain, 4)) return add(new LocalLookup(this, _hosts, domain, type, handler));

--- a/src/resolvconf.cpp
+++ b/src/resolvconf.cpp
@@ -217,28 +217,28 @@ void ResolvConf::search(const char *line, size_t size)
 {
     // we only remember the last entry, so we remove potential previous entries
     _searchpaths.clear();
-    
+
     // keep looking for paths
     while (size > 0)
     {
         // find an end-marker (whitespace or eos)
         const char *end = findwhite(line, size);
-        
+
         // are we at the end? the last element
         if (end == nullptr) return (void)_searchpaths.emplace_back(line, size);
-        
+
         // size of the part that we found
         size_t partsize = end - line;
-        
+
         // if we're not at the end, we add a part
         _searchpaths.emplace_back(line, partsize);
-        
+
         // prepare for calculating leading whitespace
         line += partsize; size -= partsize;
-        
+
         // calculate initial whitespace
-        size_t white = whitesize(line+partsize, size-partsize);
-        
+        size_t white = whitesize(line, size);
+
         // prepare more for next iteragtion
         line += white; size -= white;
     }

--- a/src/searchlookuphandler.h
+++ b/src/searchlookuphandler.h
@@ -29,7 +29,7 @@ private:
      *  the base domain, this is the domain becofore any modifications
      *  @var std::string
      */
-    const char *_basedomain;
+    std::string _basedomain;
 
     /**
      *  the search paths, these will be appended to the basedomain and attempted in-order

--- a/src/searchlookuphandler.h
+++ b/src/searchlookuphandler.h
@@ -173,10 +173,10 @@ private:
      *  Attempt the next searchpath
      *  @return operation        the operation that handles the lookup
      */
-    Operation *tryNextLookup()
+    bool tryNextLookup()
     {
-        // if there are no more paths left, return null
-        if (_index >= _searchPaths.size()) return nullptr;
+        // if there are no more paths left, return false
+        if (_index >= _searchPaths.size()) return false;
 
         // create a string to hold the next domain, and fill it with the user-domain
         std::string nextdomain(_basedomain);
@@ -185,10 +185,11 @@ private:
         nextdomain += "." + _searchPaths[_index++];
 
         // perform dns-query on the constructed path
+        // and save the operation so we can cancell it if requested
         _currentOperation = _context->query(nextdomain.c_str(), _type, _bits, this);
 
-        // return the operation
-        return _currentOperation;
+        // return success
+        return true;
     }
 
     /**

--- a/src/searchlookuphandler.h
+++ b/src/searchlookuphandler.h
@@ -1,0 +1,195 @@
+/**
+ *  @file searchlookuphandler.h
+ *  
+ *  This class wraps around a dns callback, and tries search-paths untill either all fail or one succeeds
+ *  It then passes the first successfull call, or the last failed call, back to user-space
+ *  
+ *  @author Bram van den Brink (bram.vandenbrink@copernica.nl)
+ *  @date 2022-06-29
+ *  @copyright 2022 Copernica BV
+ */
+
+#pragma once
+
+#include <dnscpp/context.h>
+
+namespace DNS {
+
+class SearchLookupHandler : public DNS::Handler
+{
+private:
+
+    /**
+     *  Ptr to context to chain calls
+     *  @var DNS::Context
+     */
+    DNS::Context *_context;
+
+    /**
+     *  ptr to the original handler, to pass calls along
+     *  @var DNS::Handler
+     */
+    DNS::Handler *_realHandler;
+
+    /**
+     *  the base domain, this is the domain becofore any modifications
+     *  @var std::string
+     */
+    std::string _basedomain;
+
+    /**
+     *  the search paths, these will be appended to the basedomain and attempted in-order
+     *  @var std::vector<std::string>
+     */
+    std::vector<std::string> _searchPaths;
+
+    /**
+     *  the index of searchpaths we are currently trying
+     *  @var int
+     */
+    size_t _index;
+
+    /**
+     *  The type of the request
+     *  @var ns_type
+     */
+    ns_type _type;
+
+    /**
+     *  The bits of the request
+     *  @var DNS::Bits
+     */
+    const DNS::Bits _bits;
+
+    /**
+     *  Destructor
+     */
+    virtual ~SearchLookupHandler() = default;
+
+    /**
+     *  Attempt the next searchpath
+     *  @return bool        is there a searchpath left
+     */
+    bool TryNext()
+    {
+        // if there are no more paths left, return false
+        if (_index >= _searchPaths.size()) return false;
+
+        // create a string to hold the next domain, and fill it with the user-domain
+        std::string nextdomain(_basedomain);
+        // add a . and the searchpath
+        nextdomain += "." + _searchPaths[_index++];
+        // perform dns-query on the constructed path
+        _context->query(nextdomain.c_str(), _type, _bits, this);
+        // return true
+        return true;
+    }
+
+    /**
+     *  Method that is called when a valid, successful, response was received.
+     * 
+     *  This is the method that you normally implement to handle the result
+     *  of a resolver-query.
+     * 
+     *  @param  operation       the operation that finished
+     *  @param  response        the received response
+     */
+    virtual void onResolved(const Operation *operation, const Response &response) 
+    {
+        // success, return to user-space
+        _realHandler->onResolved(operation, response);
+    }
+
+    /**
+     *  Method that is called when a query could not be processed or answered. 
+     * 
+     *  If the RCODE is servfail it could mean multiple things: the nameserver sent
+     *  back an actual SERVFAIL response, or is was impossible to reach the nameserver,
+     *  or the response from the nameserver was invalid.
+     * 
+     *  If you want more detailed information about the error, you can implement the
+     *  low-level onReceived() or onTimeout() methods).
+     * 
+     *  @param  operation       the operation that finished
+     *  @param  rcode           the received rcode
+     */
+    virtual void onFailure(const Operation *operation, int rcode) 
+    {
+        // try the next searchpath
+        if (TryNext()) return;
+        // return to userspace
+        _realHandler->onFailure(operation, rcode);
+    }
+
+    /**
+     *  Method that is called when a raw response is received. This includes
+     *  successful responses, error responses and truncated responses.
+     * 
+     *  The default implementation inspects the response. If it is OK it passes
+     *  it on to the onResolved() method, and when it contains an error of any
+     *  sort it calls the onFailure() method.
+     * 
+     *  @param  operation       the operation that finished
+     *  @param  response        the received response
+     */
+    virtual void onReceived(const Operation *operation, const Response &response)
+    {
+        // report to user-space
+        _realHandler->onReceived(operation, response);
+        // pass to base class
+        Handler::onReceived(operation, response);
+    }
+
+    /**
+     *  Method that is called when an operation times out.
+     * 
+     *  This normally happens when none of the nameservers sent back a response.
+     *  The default implementation is for most callers good enough: it passes to call 
+     *  on to Handler::onFailure() with a SERVFAIL error.
+     * 
+     *  @param  operation       the operation that timed out
+     */
+    virtual void onTimeout(const Operation *operation)
+    {
+        // try the next searchpath
+        if (TryNext()) return;
+        // return to user-space
+        _realHandler->onTimeout(operation);
+    }
+    
+    /**
+     *  Method that is called when the operation is cancelled
+     *  This method is immediately triggered when operation->cancel() is called.
+     * 
+     *  @param  operation       the operation that was cancelled
+     */
+    virtual void onCancelled(const Operation *operation) 
+    {
+        // should it try the next one here?
+        _realHandler->onCancelled(operation);
+    }
+
+    public:
+    /**
+     *  Constructor
+     *  @param searchpaths  the searchpaths we need to iterate one by one
+     *  @param context      the context object that will perform the querys
+     *  @param type         the type of query the user supplied
+     *  @param bits         the bits the user supplied
+     *  @param basedomain   the base domain the user supplied
+     *  @param handler      the handler the user supplied
+     */
+    SearchLookupHandler(std::vector<std::string> searchpaths, DNS::Context *context, ns_type type, const DNS::Bits bits, const char *basedomain, DNS::Handler* handler) :
+        _context(context),
+        _realHandler(handler), 
+        _basedomain(basedomain),
+        _searchPaths(searchpaths),
+        _index(0),
+        _type(type),
+        _bits(bits) {}
+
+        
+};
+
+
+}

--- a/src/searchlookuphandler.h
+++ b/src/searchlookuphandler.h
@@ -9,16 +9,27 @@
  *  @copyright 2022 Copernica BV
  */
 
+/**
+ *  Include guard
+ */
 #pragma once
 
+/**
+ *  Dependencies
+ */
 #include <dnscpp/context.h>
 
+/**
+ *  Begin of namespace
+ */
 namespace DNS {
 
+/**
+ *  Class definition
+ */
 class SearchLookupHandler : public DNS::Operation, public DNS::Handler
 {
 private:
-
     /**
      *  DNS context object to ask for querys
      *  @var DNS::Context
@@ -159,6 +170,28 @@ private:
     }
 
     /**
+     *  Attempt the next searchpath
+     *  @return operation        the operation that handles the lookup
+     */
+    Operation *tryNextLookup()
+    {
+        // if there are no more paths left, return null
+        if (_index >= _searchPaths.size()) return nullptr;
+
+        // create a string to hold the next domain, and fill it with the user-domain
+        std::string nextdomain(_basedomain);
+
+        // add a . and the searchpath
+        nextdomain += "." + _searchPaths[_index++];
+
+        // perform dns-query on the constructed path
+        _currentOperation = _context->query(nextdomain.c_str(), _type, _bits, this);
+
+        // return the operation
+        return _currentOperation;
+    }
+
+    /**
      *  Destructor
      */
     virtual ~SearchLookupHandler() = default;
@@ -185,29 +218,6 @@ private:
             // we start the lookup
             tryNextLookup();
         }
-
-    /**
-     *  Attempt the next searchpath
-     *  @return operation        the operation that handles the lookup
-     */
-    Operation *tryNextLookup()
-    {
-        // if there are no more paths left, return null
-        if (_index >= _searchPaths.size()) return nullptr;
-
-        // create a string to hold the next domain, and fill it with the user-domain
-        std::string nextdomain(_basedomain);
-
-        // add a . and the searchpath
-        nextdomain += "." + _searchPaths[_index++];
-
-        // perform dns-query on the constructed path
-        _currentOperation = _context->query(nextdomain.c_str(), _type, _bits, this);
-
-        // return the operation
-        return _currentOperation;
-    }
-
 };
 
 


### PR DESCRIPTION
Added searchlookuphandler, which wraps a dns query, and retries them untill no search paths are left.
Also added gethostname as default searchpath if none are found.

Does not yet respect ndots setting, and uses the default value of 1.