### PR TITLE
added optional for jammy builds

### DIFF
--- a/src/searchlookup.h
+++ b/src/searchlookup.h
@@ -19,6 +19,7 @@
  */
 #include <dnscpp/context.h>
 #include "../include/dnscpp/response.h"
+#include <optional>
 
 /**
  *  Begin of namespace


### PR DESCRIPTION
The library currently fails to build on Jammy due to a missing header "optional".