### PR TITLE
Share code between resolvers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ PREFIX                  ?= /usr
 INCLUDE_DIR             = ${PREFIX}/include
 LIBRARY_DIR             = ${PREFIX}/lib
 export LIBRARY_NAME		= dnscpp
-export SONAME			= 1.3
-export VERSION			= 1.3.5
+export SONAME			= 1.4
+export VERSION			= 1.4.0
 
 all:
 		$(MAKE) -C src all

--- a/include/dnscpp/authority.h
+++ b/include/dnscpp/authority.h
@@ -104,12 +104,22 @@ public:
     }
 
     /**
-     *  Expose the search-paths
-     *  @return std::vector<std::string>
+     *  The total number of searchpaths
+     *  @return size_t
      */
-    const std::vector<std::string> &searchpaths() const
+    size_t searchpaths() const
+    {
+        return _searchpaths.size();
+    }
+
+    /**
+     *  Expose one of the search-paths
+     *  @param  index
+     *  @return std::string
+     */
+    const std::string &searchpath(size_t index) const
     { 
-        return _searchpaths;
+        return _searchpaths[index];
     }
 
     /**

--- a/include/dnscpp/authority.h
+++ b/include/dnscpp/authority.h
@@ -57,6 +57,15 @@ public:
     Authority() = default;
 
     /**
+     *  Expose the /etc/hosts file
+     *  @return Hosts
+     */
+    const Hosts &hosts() const
+    {
+        return _hosts;
+    }
+
+    /**
      *  Clear the list of nameservers
      */
     void clear()
@@ -76,21 +85,22 @@ public:
     }
 
     /**
-     *  Expose the /etc/hosts file
-     *  @return Hosts
+     *  Total number of nameservers
+     *  @return size_t
      */
-    const Hosts &hosts() const
+    size_t nameservers() const
     {
-        return _hosts;
+        return _nameservers.size();
     }
 
     /**
-     *  Expose the nameservers
-     *  @return std::string<Ip>
+     *  Expose to one of the nameservers
+     *  @param  index
+     *  @return Ip
      */
-    const std::vector<Ip> &nameservers() const 
+    const Ip &nameserver(size_t index) const 
     { 
-        return _nameservers;
+        return _nameservers[index];
     }
 
     /**

--- a/include/dnscpp/authority.h
+++ b/include/dnscpp/authority.h
@@ -1,0 +1,133 @@
+/**
+ *  The authority
+ * 
+ *  Object that holds the nameservers + /etc/hosts file settings
+ *  
+ *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
+ *  @copyright 2025 Copernica BV
+ */
+
+/**
+ *  Begin of namespace
+ */
+namespace DNS {
+    
+/**
+ *  Class definition
+ */
+class Authority
+{
+private:
+    /**
+     *  The IP addresses of the servers that can be accessed
+     *  @var std::vector<Ip>
+     */
+    std::vector<Ip> _nameservers;
+
+    /**
+     *  The IP addresses of the servers that can be accessed
+     *  @var std::vector<Ip>
+     */
+    std::vector<std::string> _searchpaths;
+    
+    /**
+     *  The contents of the /etc/hosts file
+     *  @var Hosts
+     */
+    Hosts _hosts;
+
+public:
+    /**
+     *  Default constructor
+     *  @param  settings
+     */
+    Authority(const ResolvConf &settings)
+    {
+        // construct the nameservers and search paths
+        for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(settings.nameserver(i));
+        for (size_t i = 0; i < settings.searchpaths(); ++i) _searchpaths.emplace_back(settings.searchpath(i));
+    }
+
+    /**
+     *  Default constructor
+     *  @param  defaults        load the defaults
+     */
+    Authority(bool defaults)
+    {
+        // do nothing if we don't need the defaults
+        if (!defaults) return;
+        
+        // load the defaults from /etc/resolv.conf
+        ResolvConf settings;
+        
+        // copy the nameservers and search paths
+        for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(settings.nameserver(i));
+        for (size_t i = 0; i < settings.searchpaths(); ++i) _searchpaths.emplace_back(settings.searchpath(i));
+
+        // we also have to load /etc/hosts
+        if (!_hosts.load()) throw std::runtime_error("failed to load /etc/hosts");
+    }
+
+    /**
+     *  Clear the list of nameservers
+     */
+    void clear()
+    {
+        // empty the list
+        _nameservers.clear();
+    }
+
+    /**
+     *  Add a nameserver
+     *  @param  ip
+     */
+    void nameserver(const Ip &ip)
+    {
+        // add to the member in the base class
+        _nameservers.emplace_back(ip);
+    }
+
+    /**
+     *  Expose the /etc/hosts file
+     *  @return Hosts
+     */
+    const Hosts &hosts() const
+    {
+        return _hosts;
+    }
+
+    /**
+     *  Expose the nameservers
+     *  @return std::string<Ip>
+     */
+    const std::vector<Ip> &nameservers() const 
+    { 
+        return _nameservers;
+    }
+
+    /**
+     *  Expose the search-paths
+     *  @return std::vector<std::string>
+     */
+    const std::vector<std::string> &searchpaths() const
+    { 
+        return _searchpaths;
+    }
+
+    /**
+     *  Does a certain hostname exists in /etc/hosts? In that case a NXDOMAIN error should not be given
+     *  @param  hostname        hostname to check
+     *  @return bool            does it exists in /etc/hosts?
+     */
+    bool exists(const char *hostname) const
+    { 
+        // lookup the name
+        return _hosts.lookup(hostname) != nullptr;
+    }
+};
+
+/**
+ *  End of namespace
+ */
+}
+

--- a/include/dnscpp/authority.h
+++ b/include/dnscpp/authority.h
@@ -46,27 +46,15 @@ public:
         // construct the nameservers and search paths
         for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(settings.nameserver(i));
         for (size_t i = 0; i < settings.searchpaths(); ++i) _searchpaths.emplace_back(settings.searchpath(i));
-    }
-
-    /**
-     *  Default constructor
-     *  @param  defaults        load the defaults
-     */
-    Authority(bool defaults)
-    {
-        // do nothing if we don't need the defaults
-        if (!defaults) return;
-        
-        // load the defaults from /etc/resolv.conf
-        ResolvConf settings;
-        
-        // copy the nameservers and search paths
-        for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(settings.nameserver(i));
-        for (size_t i = 0; i < settings.searchpaths(); ++i) _searchpaths.emplace_back(settings.searchpath(i));
 
         // we also have to load /etc/hosts
         if (!_hosts.load()) throw std::runtime_error("failed to load /etc/hosts");
     }
+
+    /**
+     *  Default constructor
+     */
+    Authority() = default;
 
     /**
      *  Clear the list of nameservers

--- a/include/dnscpp/bits.h
+++ b/include/dnscpp/bits.h
@@ -26,6 +26,7 @@ namespace DNS {
  *      AD:     "please tell me if the data is verified (in case you know)"
  *      CD:     "checking-disabled: if you dont know if data is verified, just give me the data, no need to check it"
  *      DO:     "please also send relevant signatures like RSIG records"
+ *      RD:     "please do a recursive lookup if you do not hold the record yourself"
  * 
  *  When sent back in the response from the server to the client:
  * 

--- a/include/dnscpp/config.h
+++ b/include/dnscpp/config.h
@@ -205,6 +205,12 @@ public:
      *  @return double
      */
     double interval() const { return _interval; }
+
+    /**
+     *  Set interval before a datagram is sent again
+     *  @param  interval    time in seconds
+     */
+    void interval(double interval) { _interval = std::max(interval, 0.1); }
     
     /**
      *  Default bits to include in queries

--- a/include/dnscpp/config.h
+++ b/include/dnscpp/config.h
@@ -1,7 +1,8 @@
 /**
- *  The authority
+ *  The configuration
  * 
- *  Object that holds the nameservers + /etc/hosts file settings
+ *  Object that holds the nameservers, loaded from /etc/resolv.conf and
+ *  the /etc/hosts file settings
  *  
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
  *  @copyright 2025 Copernica BV
@@ -15,7 +16,7 @@ namespace DNS {
 /**
  *  Class definition
  */
-class Authority
+class Config
 {
 private:
     /**
@@ -41,7 +42,7 @@ public:
      *  Default constructor
      *  @param  settings
      */
-    Authority(const ResolvConf &settings)
+    Config(const ResolvConf &settings)
     {
         // construct the nameservers and search paths
         for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(settings.nameserver(i));
@@ -54,7 +55,7 @@ public:
     /**
      *  Default constructor
      */
-    Authority() = default;
+    Config() = default;
 
     /**
      *  Expose the /etc/hosts file

--- a/include/dnscpp/config.h
+++ b/include/dnscpp/config.h
@@ -37,12 +37,54 @@ private:
      */
     Hosts _hosts;
 
+    /**
+     *  Max time that we wait for a response
+     *  @var double
+     */
+    double _timeout = 60.0;
+    
+    /**
+     *  Max number of attempts / requests to send per query
+     *  @var size_t
+     */
+    size_t _attempts = 5;
+
+    /**
+     *  Interval before a datagram is sent again
+     *  @var double
+     */
+    double _interval = 2.0;
+    
+    /**
+     *  Default bits to include in queries
+     *  @var Bits
+     */
+    Bits _bits;
+    
+    /**
+     *  Should all nameservers be rotated? otherwise they will be tried in-order
+     *  @var bool
+     */
+    bool _rotate = false;
+    
+    /**
+     *  The 'ndots' setting from resolv.conf
+     *  @var ndots
+     */
+    uint8_t _ndots = 1;
+
+
 public:
     /**
      *  Default constructor
      *  @param  settings
      */
-    Config(const ResolvConf &settings)
+    Config(const ResolvConf &settings) :
+        _timeout(settings.timeout()),
+        _attempts(settings.attempts()),
+        _interval(settings.timeout()),
+        _rotate(settings.rotate()),
+        _ndots(settings.ndots())
     {
         // construct the nameservers and search paths
         for (size_t i = 0; i < settings.nameservers(); ++i) _nameservers.emplace_back(settings.nameserver(i));
@@ -133,6 +175,42 @@ public:
         // lookup the name
         return _hosts.lookup(hostname) != nullptr;
     }
+
+    /**
+     *  Max time that we wait for a response
+     *  @return double
+     */
+    double timeout() const { return _timeout; }
+    
+    /**
+     *  Max number of attempts / requests to send per query
+     *  @return size_t
+     */
+    size_t attempts() const { return _attempts; }
+
+    /**
+     *  Interval before a datagram is sent again
+     *  @return double
+     */
+    double interval() const { return _interval; }
+    
+    /**
+     *  Default bits to include in queries
+     *  @return Bits
+     */
+    const Bits &bits() const { return _bits; }
+    
+    /**
+     *  Should all nameservers be rotated? otherwise they will be tried in-order
+     *  @return bool
+     */
+    bool rotate() const { return _rotate; }
+    
+    /**
+     *  The 'ndots' setting from resolv.conf
+     *  @return ndots
+     */
+    uint8_t ndots() const { return _ndots; }
 };
 
 /**

--- a/include/dnscpp/config.h
+++ b/include/dnscpp/config.h
@@ -71,6 +71,11 @@ private:
 public:
     /**
      *  Default constructor
+     */
+    Config() = default;
+
+    /**
+     *  Default constructor
      *  @param  settings
      */
     Config(const ResolvConf &settings) :
@@ -87,11 +92,6 @@ public:
         // we also have to load /etc/hosts
         if (!_hosts.load()) throw std::runtime_error("failed to load /etc/hosts");
     }
-
-    /**
-     *  Default constructor
-     */
-    Config() = default;
 
     /**
      *  Expose the /etc/hosts file

--- a/include/dnscpp/config.h
+++ b/include/dnscpp/config.h
@@ -56,12 +56,6 @@ private:
     double _interval = 2.0;
     
     /**
-     *  Default bits to include in queries
-     *  @var Bits
-     */
-    Bits _bits;
-    
-    /**
      *  Should all nameservers be rotated? otherwise they will be tried in-order
      *  @var bool
      */
@@ -213,22 +207,28 @@ public:
     void interval(double interval) { _interval = std::max(interval, 0.1); }
     
     /**
-     *  Default bits to include in queries
-     *  @return Bits
-     */
-    const Bits &bits() const { return _bits; }
-    
-    /**
      *  Should all nameservers be rotated? otherwise they will be tried in-order
      *  @return bool
      */
     bool rotate() const { return _rotate; }
+
+    /**
+     *  Set the rotate setting: If true, nameservers will be rotated, if false, nameservers are tried in-order
+     *  @param rotate   the new setting
+     */
+    void rotate(bool rotate) { _rotate = rotate; }
     
     /**
      *  The 'ndots' setting from resolv.conf
      *  @return ndots
      */
     uint8_t ndots() const { return _ndots; }
+
+    /**
+     *  Change the ndots setting
+     *  @param  value       the new value
+     */
+    void ndots(uint8_t value) { _ndots = value; }
 };
 
 /**

--- a/include/dnscpp/config.h
+++ b/include/dnscpp/config.h
@@ -195,6 +195,12 @@ public:
     size_t attempts() const { return _attempts; }
 
     /**
+     *  Set the max number of attempts
+     *  @param  attempt     max number of attemps
+     */
+    void attempts(size_t attempts) { _attempts = attempts; }
+
+    /**
      *  Interval before a datagram is sent again
      *  @return double
      */

--- a/include/dnscpp/config.h
+++ b/include/dnscpp/config.h
@@ -181,6 +181,12 @@ public:
      *  @return double
      */
     double timeout() const { return _timeout; }
+
+    /**
+     *  Set max time to wait for a response
+     *  @param timeout      time in seconds
+     */
+    void timeout(double timeout) { _timeout = std::max(timeout, 0.1); }
     
     /**
      *  Max number of attempts / requests to send per query

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -4,7 +4,7 @@
  *  Main context for DNS lookups. This is the starting point
  * 
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
- *  @copyright 2020 - 2023 Copernica BV
+ *  @copyright 2020 - 2025 Copernica BV
  */
 
 /**
@@ -85,7 +85,7 @@ public:
     void clear()
     {
         // empty the list
-        _nameservers.clear();
+        _authority.clear();
     }
     
     /**
@@ -95,7 +95,7 @@ public:
     void nameserver(const Ip &ip)
     {
         // add to the member in the base class
-        _nameservers.emplace_back(ip);
+        _authority.nameserver(ip);
     }
     
     /**

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -40,13 +40,14 @@ class Context
 {
 private:
     /**
-     *  Core as member variable
+     *  The core of the DNS engine, this holds all the runtime resources like sockets, etc
      *  @var std::shared_ptr<Core>
      */
     std::shared_ptr<Core> _core;
 
     /**
-     *  The configuration used by this context
+     *  The configuration used by this context, by splitting the config from the core we can have multiple
+     *  contexts (for example that speak to different nameservers), that still use the same core (same sockets) 
      *  @var std::shared<Config>
      */
     std::shared_ptr<Config> _config;
@@ -86,10 +87,13 @@ public:
     Context(Loop *loop, const ResolvConf &settings);
     
     /**
-     *  No copying
-     *  @param  that
+     *  Copy constructor
+     *  This makes a copy of the context with the same core (so it uses the same 
+     *  sockets, etc), but with a new configuration (so changes to the configuration,
+     *  like other nameservers are reserved for this context only)
+     *  @param  that        the to be copied object
      */
-    Context(const Context &that) = delete;
+    Context(const Context &that);
     
     /**
      *  Destructor
@@ -97,23 +101,21 @@ public:
     virtual ~Context() = default;
     
     /**
+     *  Reset the configuration - start with all default settings
+     *  @param  defaults    load system resources for defaults (/etc/resolv.conf, /etc/hosts)
+     */
+    void reset(bool defaults = true);
+    
+    /**
      *  Clear the list of nameservers
      */
-    void clear()
-    {
-        // empty the list
-        _config->clear();
-    }
+    void clear() { _config->clear(); }
     
     /**
      *  Add a nameserver
      *  @param  ip
      */
-    void nameserver(const Ip &ip)
-    {
-        // add to the member in the base class
-        _config->nameserver(ip);
-    }
+    void nameserver(const Ip &ip) { _config->nameserver(ip); }
     
     /**
      *  Number of sockets to use

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -40,12 +40,25 @@ class Context : private Core
 {
 private:
     /**
+     *  The configuration used by this context
+     *  @var std::shared<Config>
+     */
+    std::shared_ptr<Config> _config;
+
+    /**
      *  Should the search path be respected?
      *  @param  domain      the domain to lookup
      *  @param  handler     handler that is already in use
      *  @return bool
      */
     bool searchable(const char *domain, DNS::Handler *handler) const;
+
+    /**
+     *  Constructor
+     *  @param  loop
+     *  @param  config
+     */
+    Context(Loop *loop, const std::shared_ptr<Config> &config) : Core(loop, config), _config(config) {}
 
 public:
     /**
@@ -121,8 +134,8 @@ public:
      */
     void timeout(double timeout)
     {
-        // store property, make sure the numbers are reasonably clamped
-        _timeout = std::max(timeout, 0.1);
+        // pass on
+        _config->timeout(timeout);
     }
     
     /**

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -46,6 +46,12 @@ private:
     std::shared_ptr<Config> _config;
 
     /**
+     *  Default bits to include in queries
+     *  @var Bits
+     */
+    Bits _bits;
+
+    /**
      *  Should the search path be respected?
      *  @param  domain      the domain to lookup
      *  @param  handler     handler that is already in use
@@ -169,6 +175,12 @@ public:
      *  @param  value       the new value
      */
     void capacity(size_t value);
+
+    /**
+     *  Default bits that are sent with each query
+     *  @return Bits
+     */
+    const Bits &bits() const { return _bits; }
     
     /**
      *  Enable or disable certain bits
@@ -257,9 +269,7 @@ public:
     /**
      *  Expose some getters from core
      */
-    using Core::bits;
     using Core::capacity;
-    //using Core::searchpaths;
 };
     
 /**

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -85,7 +85,7 @@ public:
     void clear()
     {
         // empty the list
-        _authority->clear();
+        _config->clear();
     }
     
     /**
@@ -95,7 +95,7 @@ public:
     void nameserver(const Ip &ip)
     {
         // add to the member in the base class
-        _authority->nameserver(ip);
+        _config->nameserver(ip);
     }
     
     /**

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -64,7 +64,7 @@ private:
      *  @param  loop
      *  @param  config
      */
-    Context(Loop *loop, const std::shared_ptr<Config> &config) : Core(loop, config), _config(config) {}
+    Context(Loop *loop, const std::shared_ptr<Config> &config) : Core(loop), _config(config) {}
 
 public:
     /**

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -57,7 +57,7 @@ public:
      *  @param  loop        your event loop
      *  @param  defaults    should system settings be loaded
      */
-    Context(Loop *loop, bool defaults = true) : Core(loop, defaults) {}
+    Context(Loop *loop, bool defaults = true);
 
     /**
      *  Constructor
@@ -66,7 +66,7 @@ public:
      * 
      *  @deprecated
      */
-    Context(Loop *loop, const ResolvConf &settings) : Core(loop, settings) {}
+    Context(Loop *loop, const ResolvConf &settings);
     
     /**
      *  No copying

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -85,7 +85,7 @@ public:
     void clear()
     {
         // empty the list
-        _authority.clear();
+        _authority->clear();
     }
     
     /**
@@ -95,7 +95,7 @@ public:
     void nameserver(const Ip &ip)
     {
         // add to the member in the base class
-        _authority.nameserver(ip);
+        _authority->nameserver(ip);
     }
     
     /**

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -144,8 +144,8 @@ public:
      */
     void interval(double interval)
     {
-        // store property, make sure the numbers are reasonably clamped
-        _interval = std::max(interval, 0.1);
+        // pass on
+        _config->interval(interval);
     }
     
     /**

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -132,31 +132,31 @@ public:
      *  Set max time to wait for a response
      *  @param timeout      time in seconds
      */
-    void timeout(double timeout)
-    {
-        // pass on
-        _config->timeout(timeout);
-    }
+    void timeout(double timeout) { _config->timeout(timeout); }
+    
+    /**
+     *  Interval before a datagram is sent again
+     *  @return double
+     */
+    double interval() const { return _config->interval(); }
     
     /**
      *  Set interval before a datagram is sent again
      *  @param  interval    time in seconds
      */
-    void interval(double interval)
-    {
-        // pass on
-        _config->interval(interval);
-    }
+    void interval(double interval) { _config->interval(interval); }
+
+    /**
+     *  Max number of attempts / requests to send per query
+     *  @return size_t
+     */
+    size_t attempts() const { return _config->attempts(); }
     
     /**
      *  Set the max number of attempts
      *  @param  attempt     max number of attemps
      */
-    void attempts(size_t attempts)
-    {
-        // pass on
-        _config->attempts(attempts);
-    }
+    void attempts(size_t attempts) { _config->attempts(attempts); }
 
     /**
      *  Set the send & receive buffer size of each individual UDP socket
@@ -179,6 +179,12 @@ public:
     void disable(const Bits &bits) { _bits.disable(bits); }
 
     /**
+     *  Should all nameservers be rotated? otherwise they will be tried in-order
+     *  @return bool
+     */
+    bool rotate() const { return _config->rotate(); }
+
+    /**
      *  Set the rotate setting: If true, nameservers will be rotated, if false, nameservers are tried in-order
      *  @param rotate   the new setting
      */
@@ -189,6 +195,12 @@ public:
      *  @param  value       the new value
      */
     void maxcalls(size_t value) { _maxcalls = value; }
+
+    /**
+     *  The 'ndots' setting from resolv.conf
+     *  @return ndots
+     */
+    uint8_t ndots() const { return _config->ndots(); }
     
     /**
      *  Change the ndots setting
@@ -246,9 +258,6 @@ public:
      *  Expose some getters from core
      */
     using Core::bits;
-    using Core::rotate;
-    using Core::expire;
-    using Core::interval;
     using Core::capacity;
     //using Core::searchpaths;
 };

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -182,7 +182,7 @@ public:
      *  Set the rotate setting: If true, nameservers will be rotated, if false, nameservers are tried in-order
      *  @param rotate   the new setting
      */
-    void rotate(bool rotate) { _rotate = rotate; }
+    void rotate(bool rotate) { _config->rotate(rotate); }
     
     /**
      *  Set the max number of calls that are made to userspace in one iteration
@@ -194,7 +194,7 @@ public:
      *  Change the ndots setting
      *  @param  value       the new value
      */
-    void ndots(uint8_t value) { _ndots = value; }
+    void ndots(uint8_t value) { _config->ndots(value); }
     
     /**
      *  Do a dns lookup and pass the result to a user-space handler object

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -154,8 +154,8 @@ public:
      */
     void attempts(size_t attempts)
     {
-        // update member
-        _attempts = attempts;
+        // pass on
+        _config->attempts(attempts);
     }
 
     /**

--- a/include/dnscpp/context.h
+++ b/include/dnscpp/context.h
@@ -237,7 +237,7 @@ public:
     using Core::expire;
     using Core::interval;
     using Core::capacity;
-    using Core::searchpaths;
+    //using Core::searchpaths;
 };
     
 /**

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -106,12 +106,6 @@ protected:
     bool _immediate = false;
 
     /**
-     *  Max time that we wait for a response
-     *  @var double
-     */
-    double _timeout = 60.0;
-    
-    /**
      *  Max number of attempts / requests to send per query
      *  @var size_t
      */
@@ -250,7 +244,7 @@ public:
      *  The time to wait for a response
      *  @return double
      */
-    double timeout() const { return _timeout; }
+    double timeout() const { return _config->timeout(); }
     
     /**
      *  Max number of attempts / number of requests to send

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -309,12 +309,6 @@ public:
     Connecting *connect(const Ip &ip, Connector *connector);
 
     /**
-     *  Expose the nameservers
-     *  @return std::string<Ip>
-     */
-    const std::vector<Ip> &nameservers() const { return _authority->nameservers(); }
-
-    /**
      *  Expose the search-paths
      *  @return std::vector<std::string>
      */

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -26,7 +26,7 @@
 #include "lookup.h"
 #include "processor.h"
 #include "timer.h"
-#include "authority.h"
+#include "config.h"
 #include <list>
 #include <deque>
 #include <memory>
@@ -64,10 +64,10 @@ protected:
     Sockets _ipv6;
 
     /**
-     *  The authority
-     *  @var std::shared_ptr<Authority>
+     *  The configuration
+     *  @var std::shared_ptr<Config>
      */
-    std::shared_ptr<Authority> _authority;
+    std::shared_ptr<Config> _config;
 
     /**
      *  All operations that are in progress and that are waiting for the next 
@@ -289,7 +289,7 @@ public:
      *  @param  hostname        hostname to check
      *  @return bool            does it exists in /etc/hosts?
      */
-    bool exists(const char *hostname) const { return _authority->exists(hostname); }
+    bool exists(const char *hostname) const { return _config->exists(hostname); }
 
     /**
      *  Send a message over a UDP socket

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -112,18 +112,6 @@ protected:
     Bits _bits;
     
     /**
-     *  Should all nameservers be rotated? otherwise they will be tried in-order
-     *  @var bool
-     */
-    bool _rotate = false;
-    
-    /**
-     *  The 'ndots' setting from resolv.conf
-     *  @var ndots
-     */
-    uint8_t _ndots = 1;
-    
-    /**
      *  Max number of operations to run at the same time
      *  @var size_t
      */
@@ -256,7 +244,7 @@ public:
      *  Should all nameservers be rotated? otherwise they will be tried in-order
      *  @var bool
      */
-    bool rotate() const { return _rotate; }
+    bool rotate() const { return _config->rotate(); }
 
     /**
      *  Does a certain hostname exists in /etc/hosts? In that case a NXDOMAIN error should not be given

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -65,9 +65,9 @@ protected:
 
     /**
      *  The authority
-     *  @var Authority
+     *  @var std::shared_ptr<Authority>
      */
-    Authority _authority;
+    std::shared_ptr<Authority> _authority;
 
     /**
      *  All operations that are in progress and that are waiting for the next 
@@ -289,7 +289,7 @@ public:
      *  @param  hostname        hostname to check
      *  @return bool            does it exists in /etc/hosts?
      */
-    bool exists(const char *hostname) const { return _authority.exists(hostname); }
+    bool exists(const char *hostname) const { return _authority->exists(hostname); }
 
     /**
      *  Send a message over a UDP socket
@@ -312,13 +312,13 @@ public:
      *  Expose the nameservers
      *  @return std::string<Ip>
      */
-    const std::vector<Ip> &nameservers() const { return _authority.nameservers(); }
+    const std::vector<Ip> &nameservers() const { return _authority->nameservers(); }
 
     /**
      *  Expose the search-paths
      *  @return std::vector<std::string>
      */
-    const std::vector<std::string> &searchpaths() const { return _authority.searchpaths(); }
+    const std::vector<std::string> &searchpaths() const { return _authority->searchpaths(); }
 
     /**
      *  Mark a lookup as cancelled and start more queues lookups

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -106,12 +106,6 @@ protected:
     bool _immediate = false;
 
     /**
-     *  Max number of attempts / requests to send per query
-     *  @var size_t
-     */
-    size_t _attempts = 5;
-
-    /**
      *  Interval before a datagram is sent again
      *  @var double
      */
@@ -250,7 +244,7 @@ public:
      *  Max number of attempts / number of requests to send
      *  @return size_t
      */
-    size_t attempts() const { return _attempts; }
+    size_t attempts() const { return _config->attempts(); }
     
     /**
      *  THe capacity: number of operations to run at the same time

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -106,12 +106,6 @@ protected:
     bool _immediate = false;
 
     /**
-     *  Interval before a datagram is sent again
-     *  @var double
-     */
-    double _interval = 2.0;
-    
-    /**
      *  Default bits to include in queries
      *  @var Bits
      */
@@ -232,7 +226,7 @@ public:
      *  The period between sending the datagram again
      *  @return double
      */
-    double interval() const { return _interval; }
+    double interval() const { return _config->interval(); }
     
     /**
      *  The time to wait for a response

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -309,12 +309,6 @@ public:
     Connecting *connect(const Ip &ip, Connector *connector);
 
     /**
-     *  Expose the search-paths
-     *  @return std::vector<std::string>
-     */
-    const std::vector<std::string> &searchpaths() const { return _authority->searchpaths(); }
-
-    /**
      *  Mark a lookup as cancelled and start more queues lookups
      *  This is called internally when userspace cancels a single operation (via Operation::cancel())
      *  @param  lookup

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -103,7 +103,7 @@ protected:
      *  Is the timer expected to expire right away
      *  @var bool
      */
-    double _immediate = false;
+    bool _immediate = false;
 
     /**
      *  Max time that we wait for a response

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -106,12 +106,6 @@ protected:
     bool _immediate = false;
 
     /**
-     *  Default bits to include in queries
-     *  @var Bits
-     */
-    Bits _bits;
-    
-    /**
      *  Max number of operations to run at the same time
      *  @var size_t
      */
@@ -234,12 +228,6 @@ public:
      */
     size_t capacity() const { return _capacity; }
     
-    /**
-     *  Default bits that are sent with each query
-     *  @return Bits
-     */
-    const Bits &bits() const { return _bits; }
-
     /**
      *  Should all nameservers be rotated? otherwise they will be tried in-order
      *  @var bool

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -64,12 +64,6 @@ protected:
     Sockets _ipv6;
 
     /**
-     *  The configuration
-     *  @var std::shared_ptr<Config>
-     */
-    std::shared_ptr<Config> _config;
-
-    /**
      *  All operations that are in progress and that are waiting for the next 
      *  (possibly first) attempt. Note that we use multiple queues so that we do
      *  not have to use a slow (priority) queue.
@@ -168,11 +162,8 @@ public:
     /**
      *  Protected constructor, only the derived class may construct it
      *  @param  loop        your event loop
-     *  @param  config      the configuration
-     * 
-     *  @deprecated
      */
-    Core(Loop *loop, const std::shared_ptr<Config> &config);
+    Core(Loop *loop);
 
     /**
      *  No copying
@@ -205,42 +196,11 @@ public:
     Loop *loop() { return _loop; }
     
     /**
-     *  The period between sending the datagram again
-     *  @return double
-     */
-    double interval() const { return _config->interval(); }
-    
-    /**
-     *  The time to wait for a response
-     *  @return double
-     */
-    double timeout() const { return _config->timeout(); }
-    
-    /**
-     *  Max number of attempts / number of requests to send
-     *  @return size_t
-     */
-    size_t attempts() const { return _config->attempts(); }
-    
-    /**
      *  THe capacity: number of operations to run at the same time
      *  @return size_t
      */
     size_t capacity() const { return _capacity; }
     
-    /**
-     *  Should all nameservers be rotated? otherwise they will be tried in-order
-     *  @var bool
-     */
-    bool rotate() const { return _config->rotate(); }
-
-    /**
-     *  Does a certain hostname exists in /etc/hosts? In that case a NXDOMAIN error should not be given
-     *  @param  hostname        hostname to check
-     *  @return bool            does it exists in /etc/hosts?
-     */
-    bool exists(const char *hostname) const { return _config->exists(hostname); }
-
     /**
      *  Send a message over a UDP socket
      *  @param  ip              target IP

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -7,7 +7,7 @@
  *  be called from user space, but they are used internally.
  * 
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
- *  @copyright 2020 - 2022 Copernica BV
+ *  @copyright 2020 - 2025 Copernica BV
  */
 
 /**
@@ -26,6 +26,7 @@
 #include "lookup.h"
 #include "processor.h"
 #include "timer.h"
+#include "authority.h"
 #include <list>
 #include <deque>
 #include <memory>
@@ -63,22 +64,10 @@ protected:
     Sockets _ipv6;
 
     /**
-     *  The IP addresses of the servers that can be accessed
-     *  @var std::vector<Ip>
+     *  The authority
+     *  @var Authority
      */
-    std::vector<Ip> _nameservers;
-
-    /**
-     *  The IP addresses of the servers that can be accessed
-     *  @var std::vector<Ip>
-     */
-    std::vector<std::string> _searchpaths;
-    
-    /**
-     *  The contents of the /etc/hosts file
-     *  @var Hosts
-     */
-    Hosts _hosts;
+    Authority _authority;
 
     /**
      *  All operations that are in progress and that are waiting for the next 
@@ -300,7 +289,7 @@ public:
      *  @param  hostname        hostname to check
      *  @return bool            does it exists in /etc/hosts?
      */
-    bool exists(const char *hostname) const { return _hosts.lookup(hostname) != nullptr; }
+    bool exists(const char *hostname) const { return _authority.exists(hostname); }
 
     /**
      *  Send a message over a UDP socket
@@ -323,13 +312,13 @@ public:
      *  Expose the nameservers
      *  @return std::string<Ip>
      */
-    const std::vector<Ip> &nameservers() const { return _nameservers; }
+    const std::vector<Ip> &nameservers() const { return _authority.nameservers(); }
 
     /**
      *  Expose the search-paths
      *  @return std::vector<std::string>
      */
-    const std::vector<std::string> &searchpaths() const { return _searchpaths; }
+    const std::vector<std::string> &searchpaths() const { return _authority.searchpaths(); }
 
     /**
      *  Mark a lookup as cancelled and start more queues lookups

--- a/include/dnscpp/core.h
+++ b/include/dnscpp/core.h
@@ -199,22 +199,22 @@ protected:
      */
     Operation *add(Lookup *lookup);
     
-    /**
-     *  Protected constructor, only the derived class may construct it
-     *  @param  loop        your event loop
-     *  @param  defaults    should defaults from resolv.conf and /etc/hosts be loaded?
-     *  @throws std::runtime_error
-     */
-    Core(Loop *loop, bool defaults);
 
+public:
     /**
      *  Protected constructor, only the derived class may construct it
      *  @param  loop        your event loop
-     *  @param  settings    settings from the resolv.conf file
+     *  @param  config      the configuration
      * 
      *  @deprecated
      */
-    Core(Loop *loop, const ResolvConf &settings);
+    Core(Loop *loop, const std::shared_ptr<Config> &config);
+
+    /**
+     *  No copying
+     *  @param  that
+     */
+    Core(const Core &that) = delete;
     
     /**
      *  Destructor
@@ -234,14 +234,6 @@ protected:
      */
     void reschedule(double now);
 
-
-public:
-    /**
-     *  No copying
-     *  @param  that
-     */
-    Core(const Core &that) = delete;
-    
     /**
      *  Expose the event loop
      *  @return Loop

--- a/include/dnscpp/hosts.h
+++ b/include/dnscpp/hosts.h
@@ -5,7 +5,7 @@
  *  and host-to-ip information in that file
  * 
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
- *  @copyright 2020 Copernica BV
+ *  @copyright 2020 - 2025 Copernica BV
  */
 
 /**
@@ -18,6 +18,7 @@
  */
 #include <map>
 #include <list>
+#include <memory>
 
 /**
  *  Begin of namespace
@@ -50,12 +51,17 @@ private:
          */
         bool operator()(const char *hostname1, const char *hostname2) const { return strcasecmp(hostname1, hostname2) < 0; }
     };
+    
+    /**
+     *  The hostname-list
+     */
+    using Hostnames = std::list<std::string>;
 
     /**
-     *  All the hostnames found
+     *  All the hostnames found - this member is just here to keep the strings in scope
      *  @var std::list
      */
-    std::list<std::string> _hostnames;
+    std::shared_ptr<Hostnames> _hostnames;
 
     /**
      *  Map of hostnames to IP addresses
@@ -83,7 +89,7 @@ public:
      *  Default constructor
      *  This does not yet read the /etc/hosts file, you need to call load() for that
      */
-    Hosts() = default;
+    Hosts() : _hostnames(std::make_shared<Hostnames>()) {}
 
     /**
      *  Constructor that immediately reads a file
@@ -91,12 +97,6 @@ public:
      *  @throws std::runtime_error
      */
     Hosts(const char *filename);
-    
-    /**
-     *  No copying
-     *  @param  that
-     */
-    Hosts(const Hosts &that) = delete;
     
     /**
      *  Destructor

--- a/include/dnscpp/libev.h
+++ b/include/dnscpp/libev.h
@@ -84,12 +84,6 @@ public:
     LibEv(struct ev_loop *loop, bool persist = true) : _loop(loop), _persist(persist) {}
     
     /**
-     *  No copying
-     *  @param  that
-     */
-    LibEv(const LibEv &that) = delete;
-    
-    /**
      *  Destructor
      */
     virtual ~LibEv() = default;

--- a/include/dnscpp/lookup.h
+++ b/include/dnscpp/lookup.h
@@ -5,7 +5,7 @@
  *  used internally, user space code does not interact with it.
  * 
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
- *  @copyright 2021 - 2022 Copernica BV
+ *  @copyright 2021 - 2025 Copernica BV
  */
 
 /**
@@ -28,6 +28,7 @@ namespace DNS {
  */
 class Handler;
 class Core;
+class Authority;
 
 /**
  *  Class definition
@@ -40,6 +41,12 @@ protected:
      *  @var Core
      */
     Core *_core;
+
+    /**
+     *  The authority (settings about nameservers, etc)
+     *  @var Authority
+     */
+    const Authority *_authority;
 
     /**
      *  The query that we're going to send
@@ -58,9 +65,10 @@ protected:
      *  @param  data        optional data (only for type = ns_o_notify)
      *  @throws std::runtime_error
      */
-    Lookup(Core *core, Handler *handler, int op, const char *dname, int type, const Bits &bits, const unsigned char *data = nullptr) :
+    Lookup(Core *core, const Authority *authority, Handler *handler, int op, const char *dname, int type, const Bits &bits, const unsigned char *data = nullptr) :
         Operation(handler),
         _core(core),
+        _authority(authority),
         _query(op, dname, type, bits, data) {}
 
 public:
@@ -74,6 +82,12 @@ public:
      *  @return Query
      */
     virtual const Query &query() const override { return _query; }
+    
+    /**
+     *  Expose the authority
+     *  @return Authority
+     */
+    const Authority *authority() const { return _authority; }
     
     /**
      *  Is this lookup still scheduled: meaning that no requests has been sent yet

--- a/include/dnscpp/lookup.h
+++ b/include/dnscpp/lookup.h
@@ -46,7 +46,7 @@ protected:
      *  The authority (settings about nameservers, etc)
      *  @var Authority
      */
-    const Authority *_authority;
+    std::shared_ptr<Authority> _authority;
 
     /**
      *  The query that we're going to send
@@ -65,7 +65,7 @@ protected:
      *  @param  data        optional data (only for type = ns_o_notify)
      *  @throws std::runtime_error
      */
-    Lookup(Core *core, const Authority *authority, Handler *handler, int op, const char *dname, int type, const Bits &bits, const unsigned char *data = nullptr) :
+    Lookup(Core *core, const std::shared_ptr<Authority> &authority, Handler *handler, int op, const char *dname, int type, const Bits &bits, const unsigned char *data = nullptr) :
         Operation(handler),
         _core(core),
         _authority(authority),
@@ -87,7 +87,7 @@ public:
      *  Expose the authority
      *  @return Authority
      */
-    const Authority *authority() const { return _authority; }
+    const std::shared_ptr<Authority> &authority() const { return _authority; }
     
     /**
      *  Is this lookup still scheduled: meaning that no requests has been sent yet

--- a/include/dnscpp/lookup.h
+++ b/include/dnscpp/lookup.h
@@ -28,7 +28,7 @@ namespace DNS {
  */
 class Handler;
 class Core;
-class Authority;
+class Config;
 
 /**
  *  Class definition
@@ -43,10 +43,10 @@ protected:
     Core *_core;
 
     /**
-     *  The authority (settings about nameservers, etc)
-     *  @var Authority
+     *  The configuration (settings about nameservers, etc)
+     *  @var Config
      */
-    std::shared_ptr<Authority> _authority;
+    std::shared_ptr<Config> _config;
 
     /**
      *  The query that we're going to send
@@ -57,6 +57,7 @@ protected:
     /**
      *  Constructor
      *  @param  core        the core object
+     *  @param  config      configuration
      *  @param  handler     user space handler
      *  @param  op          the type of operation (normally a regular query)
      *  @param  dname       the domain to lookup
@@ -65,10 +66,10 @@ protected:
      *  @param  data        optional data (only for type = ns_o_notify)
      *  @throws std::runtime_error
      */
-    Lookup(Core *core, const std::shared_ptr<Authority> &authority, Handler *handler, int op, const char *dname, int type, const Bits &bits, const unsigned char *data = nullptr) :
+    Lookup(Core *core, const std::shared_ptr<Config> &config, Handler *handler, int op, const char *dname, int type, const Bits &bits, const unsigned char *data = nullptr) :
         Operation(handler),
         _core(core),
-        _authority(authority),
+        _config(config),
         _query(op, dname, type, bits, data) {}
 
 public:
@@ -84,10 +85,10 @@ public:
     virtual const Query &query() const override { return _query; }
     
     /**
-     *  Expose the authority
-     *  @return Authority
+     *  Expose the configuration
+     *  @return Config
      */
-    const std::shared_ptr<Authority> &authority() const { return _authority; }
+    const std::shared_ptr<Config> &config() const { return _config; }
     
     /**
      *  Is this lookup still scheduled: meaning that no requests has been sent yet

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -55,6 +55,25 @@ Context::Context(Loop *loop, bool defaults) : Context(loop, createConfig(default
 Context::Context(Loop *loop, const ResolvConf &settings) : Context(loop, std::make_shared<Config>(settings)) {}
 
 /**
+ *  Copy constructor
+ *  @param  that        the to be copied object
+ */
+Context::Context(const Context &that) : _core(that._core), _config(std::make_shared<Config>(*that._config)), _bits(that._bits) {}
+
+/**
+ *  Reset the configuration - start with all default settings
+ *  @param  defaults    load system resources for defaults (/etc/resolv.conf, /etc/hosts)
+ */
+void Context::reset(bool defaults)
+{
+    // install new settings
+    _config = createConfig(defaults);
+    
+    // reset bits too
+    _bits = Bits();
+}
+
+/**
  *  Do a dns lookup
  *  @param  domain      the record name to look for
  *  @param  type        type of record (normally you ask for an 'a' record)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -47,7 +47,7 @@ static std::shared_ptr<Config> createConfig(bool defaults)
  *  @param  loop        your event loop
  *  @param  defaults    should system settings be loaded
  */
-Context::Context(Loop *loop, bool defaults) : Core(loop, createConfig(defaults)) {}
+Context::Context(Loop *loop, bool defaults) : Context(loop, createConfig(defaults)) {}
 
 /**
  *  Constructor
@@ -56,7 +56,7 @@ Context::Context(Loop *loop, bool defaults) : Core(loop, createConfig(defaults))
  * 
  *  @deprecated
  */
-Context::Context(Loop *loop, const ResolvConf &settings) : Core(loop, std::make_shared<Config>(settings)) {}
+Context::Context(Loop *loop, const ResolvConf &settings) : Context(loop, std::make_shared<Config>(settings)) {}
 
 /**
  *  Set the send & receive buffer size of each individual UDP socket

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -22,6 +22,43 @@
 namespace DNS {
 
 /**
+ *  Helper function to construct the configuration
+ *  @param  defaults
+ *  @return std::shared_ptr<Config>
+ */
+static std::shared_ptr<Config> createConfig(bool defaults)
+{
+    // if we do not have to load system defaults, we start with an empty config
+    if (!defaults) return std::make_shared<Config>();
+    
+    // load the defaults from /etc/resolv.conf
+    ResolvConf settings;
+    
+    // construct the context
+    return std::make_shared<Config>(settings);
+}    
+
+/**
+ *  Constructor
+ *  You can specify whether the system defaults from /etc/resolv.conf and
+ *  /etc/hosts should be loaded or not. If you decide to no load the system
+ *  defaults, you must explicitly assign nameservers to the context before
+ *  you can run any queries.
+ *  @param  loop        your event loop
+ *  @param  defaults    should system settings be loaded
+ */
+Context::Context(Loop *loop, bool defaults) : Core(loop, createConfig(defaults)) {}
+
+/**
+ *  Constructor
+ *  @param  loop        your event loop
+ *  @param  settings    settings parsed from the /etc/resolv.conf file
+ * 
+ *  @deprecated
+ */
+Context::Context(Loop *loop, const ResolvConf &settings) : Core(loop, std::make_shared<Config>(settings)) {}
+
+/**
  *  Set the send & receive buffer size of each individual UDP socket
  *  @param value  the value to set
  */

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -100,7 +100,7 @@ bool Context::searchable(const char *domain, DNS::Handler *handler) const
     size_t ndots = std::count(domain, domain + length + 1, '.');
     
     // compare with the 'ndots' setting
-    if (ndots >= _ndots) return false;
+    if (ndots >= _config->ndots()) return false;
     
     // do not do recursion (if the current handler already is a SearchLookup)
     return dynamic_cast<SearchLookup*>(handler) == nullptr;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -80,17 +80,17 @@ bool Context::searchable(const char *domain, DNS::Handler *handler) const
 Operation *Context::query(const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler)
 {
     // check if we should respect the search path
-    if (searchable(domain, handler)) return new SearchLookup(this, _authority, type, bits, domain, handler);
+    if (searchable(domain, handler)) return new SearchLookup(this, _config, type, bits, domain, handler);
     
     // for A and AAAA lookups we also check the /etc/hosts file
-    if (type == ns_t_a    && _authority->hosts().lookup(domain, 4)) return add(new LocalLookup(this, _authority, domain, type, handler));
-    if (type == ns_t_aaaa && _authority->hosts().lookup(domain, 6)) return add(new LocalLookup(this, _authority, domain, type, handler));
+    if (type == ns_t_a    && _config->hosts().lookup(domain, 4)) return add(new LocalLookup(this, _config, domain, type, handler));
+    if (type == ns_t_aaaa && _config->hosts().lookup(domain, 6)) return add(new LocalLookup(this, _config, domain, type, handler));
     
     // the request can throw (for example when the domain is invalid
     try
     {
         // we are going to create a self-destructing request
-        return add(new RemoteLookup(this, _authority, domain, type, bits, handler));
+        return add(new RemoteLookup(this, _config, domain, type, bits, handler));
     }
     catch (...)
     {
@@ -111,7 +111,7 @@ Operation *Context::query(const char *domain, ns_type type, const Bits &bits, DN
 Operation *Context::query(const Ip &ip, const Bits &bits, DNS::Handler *handler)
 {
     // if the /etc/hosts file already holds a record
-    if (_authority->hosts().lookup(ip)) return add(new LocalLookup(this, _authority, ip, handler));
+    if (_config->hosts().lookup(ip)) return add(new LocalLookup(this, _config, ip, handler));
 
     // pass on to the regular query method
     return query(Reverse(ip), TYPE_PTR, bits, handler);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -80,17 +80,17 @@ bool Context::searchable(const char *domain, DNS::Handler *handler) const
 Operation *Context::query(const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler)
 {
     // check if we should respect the search path
-    if (searchable(domain, handler)) return new SearchLookup(this, &_authority, type, bits, domain, handler);
+    if (searchable(domain, handler)) return new SearchLookup(this, _authority, type, bits, domain, handler);
     
     // for A and AAAA lookups we also check the /etc/hosts file
-    if (type == ns_t_a    && _authority.hosts().lookup(domain, 4)) return add(new LocalLookup(this, &_authority, domain, type, handler));
-    if (type == ns_t_aaaa && _authority.hosts().lookup(domain, 6)) return add(new LocalLookup(this, &_authority, domain, type, handler));
+    if (type == ns_t_a    && _authority->hosts().lookup(domain, 4)) return add(new LocalLookup(this, _authority, domain, type, handler));
+    if (type == ns_t_aaaa && _authority->hosts().lookup(domain, 6)) return add(new LocalLookup(this, _authority, domain, type, handler));
     
     // the request can throw (for example when the domain is invalid
     try
     {
         // we are going to create a self-destructing request
-        return add(new RemoteLookup(this, &_authority, domain, type, bits, handler));
+        return add(new RemoteLookup(this, _authority, domain, type, bits, handler));
     }
     catch (...)
     {
@@ -111,7 +111,7 @@ Operation *Context::query(const char *domain, ns_type type, const Bits &bits, DN
 Operation *Context::query(const Ip &ip, const Bits &bits, DNS::Handler *handler)
 {
     // if the /etc/hosts file already holds a record
-    if (_authority.hosts().lookup(ip)) return add(new LocalLookup(this, &_authority, ip, handler));
+    if (_authority->hosts().lookup(ip)) return add(new LocalLookup(this, _authority, ip, handler));
 
     // pass on to the regular query method
     return query(Reverse(ip), TYPE_PTR, bits, handler);

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -31,13 +31,7 @@ Core::Core(Loop *loop, const std::shared_ptr<Config> &config) :
     _loop(loop),
     _ipv4(loop, this),
     _ipv6(loop, this),
-    _config(config)
-{
-    // take over some of the settings
-    // @todo should we be using other settings for a different nameserver?
-    _rotate = _config->rotate();
-    _ndots = _config->ndots();
-}
+    _config(config) {}
 
 /**
  *  Destructor

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -35,7 +35,6 @@ Core::Core(Loop *loop, const std::shared_ptr<Config> &config) :
 {
     // take over some of the settings
     // @todo should we be using other settings for a different nameserver?
-    _timeout = _config->timeout();
     _interval = _config->timeout();
     _attempts = _config->attempts();
     _rotate = _config->rotate();

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -23,15 +23,12 @@ namespace DNS {
 /**
  *  Constructor
  *  @param  loop        your event loop
- *  @param  defaults    should defaults from resolv.conf and /etc/hosts be loaded?
- *  @param  buffersize  send & receive buffer size of each UDP socket
  *  @throws std::runtime_error
  */
-Core::Core(Loop *loop, const std::shared_ptr<Config> &config) :
+Core::Core(Loop *loop) :
     _loop(loop),
     _ipv4(loop, this),
-    _ipv6(loop, this),
-    _config(config) {}
+    _ipv6(loop, this) {}
 
 /**
  *  Destructor

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -117,7 +117,7 @@ Operation *Core::add(Lookup *lookup)
         // expire soon so that it is picked up and reported to user space
         timer(0.0);
     }
-    else if (_capacity <= _inflight || lookup->authority()->nameservers().empty())
+    else if (_capacity <= _inflight || lookup->authority()->nameservers() == 0)
     {
         // we are going to update _scheduled, check if this is the first time
         bool wasempty = _scheduled.empty();

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -36,7 +36,6 @@ Core::Core(Loop *loop, const std::shared_ptr<Config> &config) :
     // take over some of the settings
     // @todo should we be using other settings for a different nameserver?
     _interval = _config->timeout();
-    _attempts = _config->attempts();
     _rotate = _config->rotate();
     _ndots = _config->ndots();
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -35,8 +35,8 @@ Core::Core(Loop *loop, bool defaults) :
     // do nothing if we don't need the defaults
     if (!defaults)
     {
-        // use default authority
-        _authority = std::make_shared<Authority>();
+        // use default configuration
+        _config = std::make_shared<Config>();
     }
     else
     {
@@ -44,7 +44,7 @@ Core::Core(Loop *loop, bool defaults) :
         ResolvConf settings;
         
         // construct the context
-        _authority = std::make_shared<Authority>(settings);
+        _config = std::make_shared<Config>(settings);
         
         // take over some of the settings
         // @todo should we be using other settings for a different nameserver?
@@ -66,7 +66,7 @@ Core::Core(Loop *loop, const ResolvConf &settings) :
     _loop(loop),
     _ipv4(loop, this),
     _ipv6(loop, this),
-    _authority(std::make_shared<Authority>(settings))
+    _config(std::make_shared<Config>(settings))
 {
     // take over some of the settings
     _timeout = settings.timeout();
@@ -117,7 +117,7 @@ Operation *Core::add(Lookup *lookup)
         // expire soon so that it is picked up and reported to user space
         timer(0.0);
     }
-    else if (_capacity <= _inflight || lookup->authority()->nameservers() == 0)
+    else if (_capacity <= _inflight || lookup->config()->nameservers() == 0)
     {
         // we are going to update _scheduled, check if this is the first time
         bool wasempty = _scheduled.empty();

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -35,7 +35,6 @@ Core::Core(Loop *loop, const std::shared_ptr<Config> &config) :
 {
     // take over some of the settings
     // @todo should we be using other settings for a different nameserver?
-    _interval = _config->timeout();
     _rotate = _config->rotate();
     _ndots = _config->ndots();
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -30,21 +30,30 @@ namespace DNS {
 Core::Core(Loop *loop, bool defaults) :
     _loop(loop),
     _ipv4(loop, this),
-    _ipv6(loop, this),
-    _authority(defaults)
+    _ipv6(loop, this)
 {
     // do nothing if we don't need the defaults
-    if (!defaults) return;
-    
-    // load the defaults from /etc/resolv.conf
-    ResolvConf settings;
-    
-    // take over some of the settings
-    _timeout = settings.timeout();
-    _interval = settings.timeout();
-    _attempts = settings.attempts();
-    _rotate = settings.rotate();
-    _ndots = settings.ndots();
+    if (!defaults)
+    {
+        // use default authority
+        _authority = std::make_shared<Authority>();
+    }
+    else
+    {
+        // load the defaults from /etc/resolv.conf
+        ResolvConf settings;
+        
+        // construct the context
+        _authority = std::make_shared<Authority>(settings);
+        
+        // take over some of the settings
+        // @todo should we be using other settings for a different nameserver?
+        _timeout = settings.timeout();
+        _interval = settings.timeout();
+        _attempts = settings.attempts();
+        _rotate = settings.rotate();
+        _ndots = settings.ndots();
+    }
 }
 
 /**
@@ -57,7 +66,7 @@ Core::Core(Loop *loop, const ResolvConf &settings) :
     _loop(loop),
     _ipv4(loop, this),
     _ipv6(loop, this),
-    _authority(settings)
+    _authority(std::make_shared<Authority>(settings))
 {
     // take over some of the settings
     _timeout = settings.timeout();

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -27,53 +27,19 @@ namespace DNS {
  *  @param  buffersize  send & receive buffer size of each UDP socket
  *  @throws std::runtime_error
  */
-Core::Core(Loop *loop, bool defaults) :
-    _loop(loop),
-    _ipv4(loop, this),
-    _ipv6(loop, this)
-{
-    // do nothing if we don't need the defaults
-    if (!defaults)
-    {
-        // use default configuration
-        _config = std::make_shared<Config>();
-    }
-    else
-    {
-        // load the defaults from /etc/resolv.conf
-        ResolvConf settings;
-        
-        // construct the context
-        _config = std::make_shared<Config>(settings);
-        
-        // take over some of the settings
-        // @todo should we be using other settings for a different nameserver?
-        _timeout = settings.timeout();
-        _interval = settings.timeout();
-        _attempts = settings.attempts();
-        _rotate = settings.rotate();
-        _ndots = settings.ndots();
-    }
-}
-
-/**
- *  Protected constructor, only the derived class may construct it
- *  @param  loop        your event loop
- *  @param  settings    settings from the resolv.conf file
- *  @param  buffersize  send & receive buffer size of each UDP socket
- */
-Core::Core(Loop *loop, const ResolvConf &settings) :
+Core::Core(Loop *loop, const std::shared_ptr<Config> &config) :
     _loop(loop),
     _ipv4(loop, this),
     _ipv6(loop, this),
-    _config(std::make_shared<Config>(settings))
+    _config(config)
 {
     // take over some of the settings
-    _timeout = settings.timeout();
-    _interval = settings.timeout();
-    _attempts = settings.attempts();
-    _rotate = settings.rotate();
-    _ndots = settings.ndots();
+    // @todo should we be using other settings for a different nameserver?
+    _timeout = _config->timeout();
+    _interval = _config->timeout();
+    _attempts = _config->attempts();
+    _rotate = _config->rotate();
+    _ndots = _config->ndots();
 }
 
 /**

--- a/src/fakeresponse.h
+++ b/src/fakeresponse.h
@@ -7,7 +7,7 @@
  *  ourselves.
  * 
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
- *  @copyright 2020 Copernica BV
+ *  @copyright 2020 - 2025 Copernica BV
  */
 
 /**
@@ -110,7 +110,7 @@ public:
      *  @param  question    question extracted from the request
      *  @throws std::runtime_error
      */
-    FakeResponse(const Request &request, const Question &question) : _size(sizeof(HEADER)), _compressor(_buffer)
+    FakeResponse(const Request &request, const Question &question) : _buffer(""), _size(sizeof(HEADER)), _compressor(_buffer)
     {
         // make sure buffer is completely filled with zero's
         memset(_buffer, 0, sizeof(HEADER));

--- a/src/hosts.cpp
+++ b/src/hosts.cpp
@@ -4,7 +4,7 @@
  *  Implementation file for the Hosts class
  * 
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
- *  @copyright 2020 Copernica BV
+ *  @copyright 2020 - 2025 Copernica BV
  */
 
 /**
@@ -49,7 +49,7 @@ static size_t linesize(const char *line, size_t size)
  *  @param  filename        the filename to parse
  *  @throws std::runtime_error
  */
-Hosts::Hosts(const char *filename)
+Hosts::Hosts(const char *filename) : _hostnames(std::make_shared<Hostnames>())
 {
     // load initial file
     if (!load(filename)) throw std::runtime_error(std::string(filename) + ": failed to open file");
@@ -129,10 +129,10 @@ bool Hosts::parse(const char *line, size_t size)
             
             // turn the token into a string
             // @todo check if hostname is valid
-            _hostnames.emplace_back(token);
+            _hostnames->emplace_back(token);
             
             // get reference to the last item
-            const auto &hostname = _hostnames.back();
+            const auto &hostname = _hostnames->back();
             
             // insert into the maps
             _host2ip.emplace(std::make_pair(hostname.data(), ip));

--- a/src/locallookup.h
+++ b/src/locallookup.h
@@ -48,7 +48,7 @@ private:
         _handler = nullptr;
 
         // pass to the hosts (this will trigger an immediate call to the handler)
-        _authority->hosts().notify(Request(this), handler, this);
+        _config->hosts().notify(Request(this), handler, this);
         
         // done
         return true;
@@ -127,23 +127,23 @@ public:
      *  To keep the behavior of lookups consistent with the behavior of remote lookups, we set
      *  a timer so that userspace will be informed in a later tick of the event loop
      *  @param  core
-     *  @param  authority
+     *  @param  config
      *  @param  domain
      *  @param  type
      *  @param  handler
      */
-    LocalLookup(Core *core, const std::shared_ptr<Authority> &authority, const char *domain, int type, Handler *handler) :
-        Lookup(core, authority, handler, ns_o_query, domain, type, Bits{}) {}
+    LocalLookup(Core *core, const std::shared_ptr<Config> &config, const char *domain, int type, Handler *handler) :
+        Lookup(core, config, handler, ns_o_query, domain, type, Bits{}) {}
 
     /**
      *  Constructor
      *  This is a utility constructor for reverse lookups
      *  @param  core
-     *  @param  authority
+     *  @param  config
      *  @param  ip
      *  @param  handler
      */
-    LocalLookup(Core *core, const std::shared_ptr<Authority> &authority, const Ip &ip, Handler *handler) : LocalLookup(core, authority, Reverse(ip), TYPE_PTR, handler) {}
+    LocalLookup(Core *core, const std::shared_ptr<Config> &config, const Ip &ip, Handler *handler) : LocalLookup(core, config, Reverse(ip), TYPE_PTR, handler) {}
 
     /**
      *  Destructor

--- a/src/locallookup.h
+++ b/src/locallookup.h
@@ -132,7 +132,7 @@ public:
      *  @param  type
      *  @param  handler
      */
-    LocalLookup(Core *core, const Authority *authority, const char *domain, int type, Handler *handler) :
+    LocalLookup(Core *core, const std::shared_ptr<Authority> &authority, const char *domain, int type, Handler *handler) :
         Lookup(core, authority, handler, ns_o_query, domain, type, Bits{}) {}
 
     /**
@@ -143,7 +143,7 @@ public:
      *  @param  ip
      *  @param  handler
      */
-    LocalLookup(Core *core, const Authority *authority, const Ip &ip, Handler *handler) : LocalLookup(core, authority, Reverse(ip), TYPE_PTR, handler) {}
+    LocalLookup(Core *core, const std::shared_ptr<Authority> &authority, const Ip &ip, Handler *handler) : LocalLookup(core, authority, Reverse(ip), TYPE_PTR, handler) {}
 
     /**
      *  Destructor

--- a/src/locallookup.h
+++ b/src/locallookup.h
@@ -4,7 +4,7 @@
  *  Class that implements the lookup in the local /etc/hosts file
  * 
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
- *  @copyright 2020 - 2023 Copernica BV
+ *  @copyright 2020 - 2025 Copernica BV
  */
  
 /**
@@ -31,12 +31,6 @@ class LocalLookup : public Lookup
 {
 private:
     /**
-     *  Reference to the /etc/hosts file
-     *  @var Hosts
-     */
-    const Hosts &_hosts;
-    
-    /**
      *  Execute the lookup. Returns true when a user-space call was made, and false when further
      *  processing is required.
      *  @param  now         current time
@@ -54,7 +48,7 @@ private:
         _handler = nullptr;
 
         // pass to the hosts (this will trigger an immediate call to the handler)
-        _hosts.notify(Request(this), handler, this);
+        _authority->hosts().notify(Request(this), handler, this);
         
         // done
         return true;
@@ -133,22 +127,23 @@ public:
      *  To keep the behavior of lookups consistent with the behavior of remote lookups, we set
      *  a timer so that userspace will be informed in a later tick of the event loop
      *  @param  core
-     *  @param  hosts
+     *  @param  authority
      *  @param  domain
      *  @param  type
      *  @param  handler
      */
-    LocalLookup(Core *core, const Hosts &hosts, const char *domain, int type, Handler *handler) :
-        Lookup(core, handler, ns_o_query, domain, type, Bits{}), _hosts(hosts) {}
+    LocalLookup(Core *core, const Authority *authority, const char *domain, int type, Handler *handler) :
+        Lookup(core, authority, handler, ns_o_query, domain, type, Bits{}) {}
 
     /**
      *  Constructor
      *  This is a utility constructor for reverse lookups
-     *  @param  hosts
+     *  @param  core
+     *  @param  authority
      *  @param  ip
      *  @param  handler
      */
-    LocalLookup(Core *core, const Hosts &hosts, const Ip &ip, Handler *handler) : LocalLookup(core, hosts, Reverse(ip), TYPE_PTR, handler) {}
+    LocalLookup(Core *core, const Authority *authority, const Ip &ip, Handler *handler) : LocalLookup(core, authority, Reverse(ip), TYPE_PTR, handler) {}
 
     /**
      *  Destructor

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -4,7 +4,7 @@
  *  Implementation file for the RemoteLookup class
  * 
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
- *  @copyright 2020 - 2021 Copernica BV
+ *  @copyright 2020 - 2025 Copernica BV
  */
 
 /**
@@ -26,13 +26,14 @@ namespace DNS {
 /**
  *  Constructor
  *  @param  core        dns core object
+ *  @param  authority   authority with settings about nameservers, etc
  *  @param  domain      the domain of the lookup
  *  @param  type        the type of the request
  *  @param  bits        bits to include
  *  @param  handler     user space object
  */
-RemoteLookup::RemoteLookup(Core *core, const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler) : 
-    Lookup(core, handler, ns_o_query, domain, type, bits), _id(rand()) {}
+RemoteLookup::RemoteLookup(Core *core, const Authority *authority, const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler) : 
+    Lookup(core, authority, handler, ns_o_query, domain, type, bits), _id(rand()) {}
 
 /**
  *  Destructor
@@ -180,7 +181,7 @@ bool RemoteLookup::execute(double now)
     if (_connections > 0) return false;
 
     // access to the nameservers + the number we have
-    auto &nameservers = _core->nameservers();
+    auto &nameservers = _authority->nameservers();
     size_t nscount = nameservers.size();
     
     // what if there are no nameservers?
@@ -233,7 +234,7 @@ bool RemoteLookup::report(const Response &response)
     
     // there was a NXDOMAIN error, which we should not communicate if our /etc/hosts
     // file does have a record for this hostname, check this
-    if (!_core->exists(question.name())) return cleanup()->onReceived(this, response), true;
+    if (!_authority->exists(question.name())) return cleanup()->onReceived(this, response), true;
     
     // get the original request (so that the response can match the request)
     Request request(this);

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -82,7 +82,7 @@ bool RemoteLookup::exhausted() const
     if (_connections > 0) return true;
     
     // if max number of datagrams has not yet been reached
-    return _datagrams >= _core->attempts();
+    return _datagrams >= _config->attempts();
 }
 
 /**
@@ -97,10 +97,10 @@ double RemoteLookup::delay(double now) const
     if (_datagrams == 0 || _handler == nullptr) return 0.0;
     
     // if already doing a tcp lookup, or when all attemps have passed, we wait until the expire-time
-    if (_connections > 0 || _datagrams >= _core->attempts()) return std::max(0.0, _last + _core->timeout() - now);
+    if (_connections > 0 || _datagrams >= _config->attempts()) return std::max(0.0, _last + _config->timeout() - now);
     
     // wait until we can send a next datagram
-    return std::max(_last + _core->interval() - now, 0.0);
+    return std::max(_last + _config->interval() - now, 0.0);
 }
 
 /**
@@ -172,10 +172,10 @@ bool RemoteLookup::timeout()
 bool RemoteLookup::execute(double now)
 {
     // when job times out
-    if ((_connections > 0 || _datagrams >= _core->attempts()) && now > _last + _core->timeout()) return timeout();
+    if ((_connections > 0 || _datagrams >= _config->attempts()) && now > _last + _config->timeout()) return timeout();
 
     // if we reached the max attempts we stop sending out more datagrams
-    if (_datagrams >= _core->attempts()) return false;
+    if (_datagrams >= _config->attempts()) return false;
 
     // if the operation is already using tcp we simply wait for that
     if (_connections > 0) return false;
@@ -187,7 +187,7 @@ bool RemoteLookup::execute(double now)
     if (nscount == 0) return timeout();
 
     // which nameserver should we sent now?
-    size_t target = _core->rotate() ? (_datagrams + _id) % nscount : _datagrams % nscount;
+    size_t target = _config->rotate() ? (_datagrams + _id) % nscount : _datagrams % nscount;
     
     // send a datagram to each nameserver
     auto &nameserver = _config->nameserver(target);

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -32,7 +32,7 @@ namespace DNS {
  *  @param  bits        bits to include
  *  @param  handler     user space object
  */
-RemoteLookup::RemoteLookup(Core *core, const Authority *authority, const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler) : 
+RemoteLookup::RemoteLookup(Core *core, const std::shared_ptr<Authority> &authority, const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler) : 
     Lookup(core, authority, handler, ns_o_query, domain, type, bits), _id(rand()) {}
 
 /**

--- a/src/remotelookup.cpp
+++ b/src/remotelookup.cpp
@@ -181,8 +181,7 @@ bool RemoteLookup::execute(double now)
     if (_connections > 0) return false;
 
     // access to the nameservers + the number we have
-    auto &nameservers = _authority->nameservers();
-    size_t nscount = nameservers.size();
+    size_t nscount = _authority->nameservers();
     
     // what if there are no nameservers?
     if (nscount == 0) return timeout();
@@ -191,7 +190,7 @@ bool RemoteLookup::execute(double now)
     size_t target = _core->rotate() ? (_datagrams + _id) % nscount : _datagrams % nscount;
     
     // send a datagram to each nameserver
-    auto &nameserver = nameservers[target];
+    auto &nameserver = _authority->nameserver(target);
 
     // send a datagram to this server
     auto *inbound = _core->datagram(nameserver, _query);

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -208,13 +208,13 @@ public:
     /**
      *  Constructor
      *  @param  core        dns core object
-     *  @param  authority   the authority to use
+     *  @param  config      the configuration to use
      *  @param  domain      the domain of the lookup
      *  @param  type        type of records to look for
      *  @param  bits        the bits to include in the request
      *  @param  handler     user space object interested in the result
      */
-    RemoteLookup(Core *core, const std::shared_ptr<Authority> &authority, const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler);
+    RemoteLookup(Core *core, const std::shared_ptr<Config> &config, const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler);
     
     /**
      *  No copying

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -4,7 +4,7 @@
  *  Class that encapsulates all data that is needed for a single request
  * 
  *  @author Emiel Bruijntjes <emiel.bruijntjes@copernica.com>
- *  @copyright 2020 - 2021 Copernica BV
+ *  @copyright 2020 - 2025 Copernica BV
  */
 
 /**
@@ -208,12 +208,13 @@ public:
     /**
      *  Constructor
      *  @param  core        dns core object
+     *  @param  authority   the authority to use
      *  @param  domain      the domain of the lookup
      *  @param  type        type of records to look for
      *  @param  bits        the bits to include in the request
      *  @param  handler     user space object interested in the result
      */
-    RemoteLookup(Core *core, const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler);
+    RemoteLookup(Core *core, const Authority *authority, const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler);
     
     /**
      *  No copying

--- a/src/remotelookup.h
+++ b/src/remotelookup.h
@@ -214,7 +214,7 @@ public:
      *  @param  bits        the bits to include in the request
      *  @param  handler     user space object interested in the result
      */
-    RemoteLookup(Core *core, const Authority *authority, const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler);
+    RemoteLookup(Core *core, const std::shared_ptr<Authority> &authority, const char *domain, ns_type type, const Bits &bits, DNS::Handler *handler);
     
     /**
      *  No copying

--- a/src/searchlookup.h
+++ b/src/searchlookup.h
@@ -154,14 +154,11 @@ private:
         // do nothing if we already have exhausted all calls
         if (_index == size_t(-1)) return false;
 
-        // shortcut to the search-paths
-        const auto &searchpaths = _authority->searchpaths();
-        
         // if there are no more paths left, return false
-        if (_index >= searchpaths.size()) return finalize();
+        if (_index >= _authority->searchpaths()) return finalize();
 
         // the next path to check
-        const auto &nextdomain = searchpaths[_index++];
+        const auto &nextdomain = _authority->searchpath(_index++);
         
         // for empty domains we do not need to concatenate
         if (nextdomain.empty()) return finalize();

--- a/src/searchlookup.h
+++ b/src/searchlookup.h
@@ -32,10 +32,10 @@ class SearchLookup : public DNS::Operation, public DNS::Handler
 {
 private:
     /**
-     *  DNS context object to ask for querys
-     *  @var DNS::Context
+     *  DNS core object to ask for querys
+     *  @var DNS::Core
      */
-    DNS::Context *_context;
+    DNS::Core *_core;
     
     /**
      *  The congifuration to use
@@ -171,7 +171,7 @@ private:
 
         // perform dns-query on the constructed path
         // and save the operation so we can cancell it if requested
-        _operation = _context->query(nexthost.c_str(), _type, _bits, this);
+        _operation = _core->query(_config, nexthost.c_str(), _type, _bits, this);
 
         // return success
         return true;
@@ -184,7 +184,7 @@ private:
     bool finalize()
     {
         // start a lookup for just the requested domain
-        _operation = _context->query(_basedomain.c_str(), _type, _bits, this);
+        _operation = _core->query(_config, _basedomain.c_str(), _type, _bits, this);
         
         // update index to prevent loops
         _index = size_t(-1);
@@ -201,16 +201,16 @@ private:
 public:
     /**
      *  Constructor
-     *  @param context      the context object that will perform the queries
+     *  @param core         the context object that will perform the queries
      *  @param config       object that knows which search-path to use
      *  @param type         the type of query the user supplied
      *  @param bits         the bits the user supplied
      *  @param basedomain   the base domain the user supplied
      *  @param handler      the handler the user supplied
      */
-    SearchLookup(DNS::Context *context, const std::shared_ptr<Config> &config, ns_type type, const DNS::Bits bits, const char *basedomain, DNS::Handler* handler) :
+    SearchLookup(DNS::Core *core, const std::shared_ptr<Config> &config, ns_type type, const DNS::Bits bits, const char *basedomain, DNS::Handler* handler) :
         Operation(handler),
-        _context(context),
+        _core(core),
         _config(config),
         _basedomain(basedomain),
         _index(0),

--- a/src/searchlookup.h
+++ b/src/searchlookup.h
@@ -38,10 +38,10 @@ private:
     DNS::Context *_context;
     
     /**
-     *  The authority to use
-     *  @var std::shared_ptr<Authority>
+     *  The congifuration to use
+     *  @var std::shared_ptr<Config>
      */
-    std::shared_ptr<Authority> _authority;
+    std::shared_ptr<Config> _config;
 
     /**
      *  the base domain, this is the domain becofore any modifications
@@ -155,10 +155,10 @@ private:
         if (_index == size_t(-1)) return false;
 
         // if there are no more paths left, return false
-        if (_index >= _authority->searchpaths()) return finalize();
+        if (_index >= _config->searchpaths()) return finalize();
 
         // the next path to check
-        const auto &nextdomain = _authority->searchpath(_index++);
+        const auto &nextdomain = _config->searchpath(_index++);
         
         // for empty domains we do not need to concatenate
         if (nextdomain.empty()) return finalize();
@@ -202,16 +202,16 @@ public:
     /**
      *  Constructor
      *  @param context      the context object that will perform the queries
-     *  @param authority    object that knows which search-path to use
+     *  @param config       object that knows which search-path to use
      *  @param type         the type of query the user supplied
      *  @param bits         the bits the user supplied
      *  @param basedomain   the base domain the user supplied
      *  @param handler      the handler the user supplied
      */
-    SearchLookup(DNS::Context *context, const std::shared_ptr<Authority> &authority, ns_type type, const DNS::Bits bits, const char *basedomain, DNS::Handler* handler) :
+    SearchLookup(DNS::Context *context, const std::shared_ptr<Config> &config, ns_type type, const DNS::Bits bits, const char *basedomain, DNS::Handler* handler) :
         Operation(handler),
         _context(context),
-        _authority(authority),
+        _config(config),
         _basedomain(basedomain),
         _index(0),
         _type(type),

--- a/src/searchlookup.h
+++ b/src/searchlookup.h
@@ -39,10 +39,9 @@ private:
     
     /**
      *  The authority to use
-     *  @var Authority
+     *  @var std::shared_ptr<Authority>
      */
-    const Authority *_authority;
-    
+    std::shared_ptr<Authority> _authority;
 
     /**
      *  the base domain, this is the domain becofore any modifications
@@ -212,7 +211,7 @@ public:
      *  @param basedomain   the base domain the user supplied
      *  @param handler      the handler the user supplied
      */
-    SearchLookup(DNS::Context *context, const Authority *authority, ns_type type, const DNS::Bits bits, const char *basedomain, DNS::Handler* handler) :
+    SearchLookup(DNS::Context *context, const std::shared_ptr<Authority> &authority, ns_type type, const DNS::Bits bits, const char *basedomain, DNS::Handler* handler) :
         Operation(handler),
         _context(context),
         _authority(authority),

--- a/src/searchlookup.h
+++ b/src/searchlookup.h
@@ -5,8 +5,7 @@
  *  It then passes the first successfull call, or the last failed call, back to user-space
  *  
  *  @author Bram van den Brink (bram.vandenbrink@copernica.nl)
- *  @date 2022-06-29
- *  @copyright 2022 Copernica BV
+ *  @copyright 2022 - 2025 Copernica BV
  */
 
 /**
@@ -37,6 +36,13 @@ private:
      *  @var DNS::Context
      */
     DNS::Context *_context;
+    
+    /**
+     *  The authority to use
+     *  @var Authority
+     */
+    const Authority *_authority;
+    
 
     /**
      *  the base domain, this is the domain becofore any modifications
@@ -150,7 +156,7 @@ private:
         if (_index == size_t(-1)) return false;
 
         // shortcut to the search-paths
-        const auto &searchpaths = _context->searchpaths();
+        const auto &searchpaths = _authority->searchpaths();
         
         // if there are no more paths left, return false
         if (_index >= searchpaths.size()) return finalize();
@@ -199,15 +205,17 @@ private:
 public:
     /**
      *  Constructor
-     *  @param context      the context object that will perform the querys
+     *  @param context      the context object that will perform the queries
+     *  @param authority    object that knows which search-path to use
      *  @param type         the type of query the user supplied
      *  @param bits         the bits the user supplied
      *  @param basedomain   the base domain the user supplied
      *  @param handler      the handler the user supplied
      */
-    SearchLookup(DNS::Context *context, ns_type type, const DNS::Bits bits, const char *basedomain, DNS::Handler* handler) :
+    SearchLookup(DNS::Context *context, const Authority *authority, ns_type type, const DNS::Bits bits, const char *basedomain, DNS::Handler* handler) :
         Operation(handler),
         _context(context),
+        _authority(authority),
         _basedomain(basedomain),
         _index(0),
         _type(type),

--- a/test/a.cpp
+++ b/test/a.cpp
@@ -92,9 +92,10 @@ public:
 
     /**
      *  Method that is called when a raw response is received
+     *  @param  operation       the finished operation
      *  @param  response        the received response
      */
-    virtual void onReceived(const DNS::Response &response) override
+    virtual void onReceived(const DNS::Operation *operation, const DNS::Response &response) override
     {
         std::cout << "validation response is in" << std::endl;
         
@@ -154,9 +155,10 @@ public:
 
     /**
      *  Method that is called when a raw response is received
+     *  @param  operation       the reporting operation
      *  @param  response        the received response
      */
-    virtual void onReceived(const DNS::Response &response) override
+    virtual void onReceived(const DNS::Operation *operation, const DNS::Response &response) override
     {
         // go look for the A record
         for (size_t i = 0; i < response.answers(); ++i)
@@ -201,7 +203,7 @@ int main()
     context.nameserver(DNS::Ip("8.8.8.8"));
     
     // do a query
-    context.query("www.example.com", ns_t_a, &handler);
+    context.query("www.google.com", ns_t_a, &handler);
     
     // run the event loop
     ev_run(loop, 0);


### PR DESCRIPTION
The DNS::Context class has been refactored so that it can be copied. The copy and the original object share the same "core" (meaning: they use the same sockets), but can have a different configuration (for example speak with other nameservers).